### PR TITLE
fix: enforce session-bound authorization on account-scoped commands

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -333,6 +333,43 @@ pub async fn get_current_user(pool: &SqlitePool, token: &str) -> Result<User, Au
     })
 }
 
+/// Verifies that the caller is allowed to act on `account_id`.
+///
+/// `account_id` values that don't correspond to a registered user (guest IDs,
+/// which are client-generated UUIDs never written to the `users` table) are
+/// allowed through unchanged, since guests have no server-side account to
+/// protect. Account IDs that do belong to a registered user require a valid,
+/// unexpired session token for that same user — callers must not be able to
+/// read or modify another account's data by simply naming its ID.
+pub async fn authorize_account(
+    pool: &SqlitePool,
+    token: Option<&str>,
+    account_id: &str,
+) -> Result<(), AuthError> {
+    let Ok(numeric_id) = account_id.parse::<i64>() else {
+        return Ok(());
+    };
+
+    let is_registered_user = sqlx::query("SELECT 1 FROM users WHERE id = ?")
+        .bind(numeric_id)
+        .fetch_optional(pool)
+        .await?
+        .is_some();
+
+    if !is_registered_user {
+        return Ok(());
+    }
+
+    let token = token.ok_or(AuthError::SessionExpired)?;
+    let user = get_current_user(pool, token).await?;
+
+    if user.id != account_id {
+        return Err(AuthError::InvalidCredentials);
+    }
+
+    Ok(())
+}
+
 pub async fn update_status(pool: &SqlitePool, token: &str, status: &str) -> Result<(), AuthError> {
     let now = Utc::now().to_rfc3339();
 

--- a/src-tauri/src/commands/chat_commands.rs
+++ b/src-tauri/src/commands/chat_commands.rs
@@ -1,3 +1,4 @@
+use crate::auth::{authorize_account, AuthError};
 use crate::error::AppError;
 use crate::memory::service::MemoryService;
 use crate::models::chat::ChatMessage;
@@ -10,6 +11,26 @@ use crate::AppState;
 use serde_json::Value;
 use std::sync::atomic::Ordering;
 use tauri::AppHandle;
+
+fn map_auth_err(error: AuthError) -> String {
+    match error {
+        AuthError::SessionExpired => "Session expired".to_string(),
+        _ => "Not authorized for this account".to_string(),
+    }
+}
+
+async fn check_account(
+    state: &tauri::State<'_, AppState>,
+    token: Option<&str>,
+    account_id: Option<&str>,
+) -> Result<(), String> {
+    match account_id {
+        Some(id) => authorize_account(&state.db, token, id)
+            .await
+            .map_err(map_auth_err),
+        None => Ok(()),
+    }
+}
 
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
@@ -26,7 +47,9 @@ pub async fn chat_stream(
     provider_type: Option<ProviderType>,
     provider_config_id: Option<i64>,
     account_id: Option<String>,
+    token: Option<String>,
 ) -> Result<(), String> {
+    check_account(&state, token.as_deref(), account_id.as_deref()).await?;
     let my_generation_id = state.current_generation_id.load(Ordering::SeqCst);
 
     let provider_type = provider_type.unwrap_or(ProviderType::OllamaLocal);
@@ -133,7 +156,9 @@ pub async fn chat(
     options: Option<Value>,
     provider_type: Option<ProviderType>,
     account_id: Option<String>,
+    token: Option<String>,
 ) -> Result<String, String> {
+    check_account(&state, token.as_deref(), account_id.as_deref()).await?;
     let provider = state
         .provider_selector
         .get_provider(
@@ -165,7 +190,9 @@ pub async fn generate_chat_title(
     user_name: Option<String>,
     provider_type: Option<ProviderType>,
     account_id: Option<String>,
+    token: Option<String>,
 ) -> Result<Option<String>, String> {
+    check_account(&state, token.as_deref(), account_id.as_deref()).await?;
     let provider = match state
         .provider_selector
         .get_provider(

--- a/src-tauri/src/commands/memory_commands.rs
+++ b/src-tauri/src/commands/memory_commands.rs
@@ -1,3 +1,4 @@
+use crate::auth::{authorize_account, AuthError};
 use crate::memory::service::MemoryService;
 use crate::memory::service::{
     MemoryConnectionTestResult, MemoryForgetMessageInput, MemoryRelatedQuery,
@@ -13,11 +14,30 @@ fn service(state: &tauri::State<'_, AppState>) -> MemoryService {
     MemoryService::new(state.db.clone())
 }
 
+fn map_auth_err(error: AuthError) -> String {
+    match error {
+        AuthError::SessionExpired => "Session expired".to_string(),
+        _ => "Not authorized for this account".to_string(),
+    }
+}
+
+async fn check_owner(
+    state: &tauri::State<'_, AppState>,
+    token: Option<&str>,
+    owner_id: &str,
+) -> Result<(), String> {
+    authorize_account(&state.db, token, owner_id)
+        .await
+        .map_err(map_auth_err)
+}
+
 #[tauri::command]
 pub async fn memory_get_settings(
     state: tauri::State<'_, AppState>,
     owner_id: String,
+    token: Option<String>,
 ) -> Result<MemorySettings, String> {
+    check_owner(&state, token.as_deref(), &owner_id).await?;
     service(&state)
         .get_settings(&owner_id)
         .await
@@ -28,7 +48,9 @@ pub async fn memory_get_settings(
 pub async fn memory_update_settings(
     state: tauri::State<'_, AppState>,
     settings: MemorySettings,
+    token: Option<String>,
 ) -> Result<MemorySettings, String> {
+    check_owner(&state, token.as_deref(), &settings.owner_id).await?;
     service(&state)
         .update_settings(settings)
         .await
@@ -39,7 +61,9 @@ pub async fn memory_update_settings(
 pub async fn memory_test_connection(
     state: tauri::State<'_, AppState>,
     owner_id: String,
+    token: Option<String>,
 ) -> Result<MemoryConnectionTestResult, String> {
+    check_owner(&state, token.as_deref(), &owner_id).await?;
     service(&state)
         .test_connection(&owner_id)
         .await
@@ -50,7 +74,9 @@ pub async fn memory_test_connection(
 pub async fn memory_list(
     state: tauri::State<'_, AppState>,
     query: MemoryListQuery,
+    token: Option<String>,
 ) -> Result<Vec<MemoryRecord>, String> {
+    check_owner(&state, token.as_deref(), &query.owner_id).await?;
     service(&state)
         .list(query)
         .await
@@ -61,7 +87,9 @@ pub async fn memory_list(
 pub async fn memory_search(
     state: tauri::State<'_, AppState>,
     query: MemorySearchQuery,
+    token: Option<String>,
 ) -> Result<Vec<MemoryRecord>, String> {
+    check_owner(&state, token.as_deref(), &query.owner_id).await?;
     service(&state)
         .search(query)
         .await
@@ -72,7 +100,9 @@ pub async fn memory_search(
 pub async fn memory_update(
     state: tauri::State<'_, AppState>,
     input: MemoryUpdateInput,
+    token: Option<String>,
 ) -> Result<MemoryRecord, String> {
+    check_owner(&state, token.as_deref(), &input.owner_id).await?;
     service(&state)
         .update(input)
         .await
@@ -84,7 +114,9 @@ pub async fn memory_delete(
     state: tauri::State<'_, AppState>,
     owner_id: String,
     memory_id: String,
+    token: Option<String>,
 ) -> Result<(), String> {
+    check_owner(&state, token.as_deref(), &owner_id).await?;
     service(&state)
         .delete(&owner_id, &memory_id)
         .await
@@ -97,7 +129,9 @@ pub async fn memory_clear_scope(
     owner_id: String,
     scope: MemoryScope,
     scope_owner_id: Option<String>,
+    token: Option<String>,
 ) -> Result<(), String> {
+    check_owner(&state, token.as_deref(), &owner_id).await?;
     service(&state)
         .clear_scope(&owner_id, scope, scope_owner_id.as_deref())
         .await
@@ -108,7 +142,9 @@ pub async fn memory_clear_scope(
 pub async fn memory_clear_all(
     state: tauri::State<'_, AppState>,
     owner_id: String,
+    token: Option<String>,
 ) -> Result<(), String> {
+    check_owner(&state, token.as_deref(), &owner_id).await?;
     service(&state)
         .clear_all(&owner_id)
         .await
@@ -119,7 +155,9 @@ pub async fn memory_clear_all(
 pub async fn memory_remember_message(
     state: tauri::State<'_, AppState>,
     input: MemoryRememberMessageInput,
+    token: Option<String>,
 ) -> Result<Vec<crate::memory::types::MemoryOperationResult>, String> {
+    check_owner(&state, token.as_deref(), &input.owner_id).await?;
     service(&state)
         .remember_message(input)
         .await
@@ -130,7 +168,9 @@ pub async fn memory_remember_message(
 pub async fn memory_forget_message(
     state: tauri::State<'_, AppState>,
     input: MemoryForgetMessageInput,
+    token: Option<String>,
 ) -> Result<(), String> {
+    check_owner(&state, token.as_deref(), &input.owner_id).await?;
     service(&state)
         .forget_message(input)
         .await
@@ -141,7 +181,9 @@ pub async fn memory_forget_message(
 pub async fn memory_get_related(
     state: tauri::State<'_, AppState>,
     query: MemoryRelatedQuery,
+    token: Option<String>,
 ) -> Result<Vec<MemoryRecord>, String> {
+    check_owner(&state, token.as_deref(), &query.owner_id).await?;
     let search = MemorySearchQuery {
         owner_id: query.owner_id,
         query: query.query.or(query.message_id).unwrap_or_default(),
@@ -162,7 +204,9 @@ pub async fn memory_get_related(
 pub async fn memory_enqueue_completed_turn(
     state: tauri::State<'_, AppState>,
     input: MemoryCompletedTurnInput,
+    token: Option<String>,
 ) -> Result<MemoryProcessingRecord, String> {
+    check_owner(&state, token.as_deref(), &input.owner_id).await?;
     service(&state)
         .process_completed_turn(input)
         .await

--- a/src-tauri/src/commands/provider_commands.rs
+++ b/src-tauri/src/commands/provider_commands.rs
@@ -1,8 +1,29 @@
+use crate::auth::{authorize_account, AuthError};
 use crate::error::AppError;
 use crate::models::chat::ModelDetails;
 use crate::providers::base::{ProviderConfig, ProviderStatus, ProviderType};
 use crate::providers::factory::ProviderFactory;
 use crate::AppState;
+
+fn map_auth_err(error: AuthError) -> String {
+    match error {
+        AuthError::SessionExpired => "Session expired".to_string(),
+        _ => "Not authorized for this account".to_string(),
+    }
+}
+
+async fn check_account(
+    state: &tauri::State<'_, AppState>,
+    token: Option<&str>,
+    account_id: Option<&str>,
+) -> Result<(), String> {
+    match account_id {
+        Some(id) => authorize_account(&state.db, token, id)
+            .await
+            .map_err(map_auth_err),
+        None => Ok(()),
+    }
+}
 
 #[derive(serde::Serialize)]
 pub struct ProviderStatusResponse {
@@ -76,9 +97,11 @@ fn config_health_key(config: &ProviderConfig) -> i64 {
 pub async fn get_providers(
     state: tauri::State<'_, AppState>,
     account_id: Option<String>,
+    token: Option<String>,
 ) -> Result<Vec<ProviderStatusResponse>, String> {
-    let selector = &state.provider_selector;
     let account_id = normalize_account_arg(account_id);
+    check_account(&state, token.as_deref(), account_id.as_deref()).await?;
+    let selector = &state.provider_selector;
     let configs = selector
         .get_provider_configs(account_id.as_deref())
         .await
@@ -102,9 +125,11 @@ pub async fn get_providers(
 pub async fn get_provider_and_models(
     state: tauri::State<'_, AppState>,
     account_id: Option<String>,
+    token: Option<String>,
 ) -> Result<ProviderAndModelsResponse, String> {
-    let selector = &state.provider_selector;
     let account_id = normalize_account_arg(account_id);
+    check_account(&state, token.as_deref(), account_id.as_deref()).await?;
+    let selector = &state.provider_selector;
     let configs = selector
         .get_provider_configs(account_id.as_deref())
         .await
@@ -137,8 +162,10 @@ pub async fn get_provider_models(
     state: tauri::State<'_, AppState>,
     provider_type: ProviderType,
     account_id: Option<String>,
+    token: Option<String>,
 ) -> Result<Vec<ModelDetails>, String> {
     let account_id = normalize_account_arg(account_id);
+    check_account(&state, token.as_deref(), account_id.as_deref()).await?;
     let configs = state
         .provider_selector
         .get_provider_configs(account_id.as_deref())
@@ -185,8 +212,10 @@ pub async fn update_provider_config(
     state: tauri::State<'_, AppState>,
     request: UpdateProviderConfigRequest,
     account_id: Option<String>,
+    token: Option<String>,
 ) -> Result<(), String> {
     let account_id = normalize_account_arg(account_id);
+    check_account(&state, token.as_deref(), account_id.as_deref()).await?;
     state
         .provider_selector
         .update_provider_config(
@@ -230,8 +259,10 @@ pub async fn add_provider(
     state: tauri::State<'_, AppState>,
     request: AddProviderRequest,
     account_id: Option<String>,
+    token: Option<String>,
 ) -> Result<i64, String> {
     let account_id = normalize_account_arg(account_id);
+    check_account(&state, token.as_deref(), account_id.as_deref()).await?;
     state
         .provider_selector
         .add_provider_config(
@@ -254,8 +285,10 @@ pub async fn delete_provider(
     state: tauri::State<'_, AppState>,
     account_id: Option<String>,
     id: i64,
+    token: Option<String>,
 ) -> Result<(), String> {
     let account_id = normalize_account_arg(account_id);
+    check_account(&state, token.as_deref(), account_id.as_deref()).await?;
     state
         .provider_selector
         .delete_provider_config(account_id.as_deref(), id)

--- a/src/features/chat/hooks/useChatStream.ts
+++ b/src/features/chat/hooks/useChatStream.ts
@@ -4,7 +4,7 @@ import { useShallow } from "zustand/react/shallow";
 import type { ChatMessage, Attachment, Message } from "@/types/chat";
 import { useChatStore } from "@/store/chatStore";
 import { sanitizeOutput } from "@/lib/chat/sanitize";
-import { loggedInvoke } from "@/lib/utils/utils";
+import { loggedInvoke, getSessionToken } from "@/lib/utils/utils";
 import { useNotify } from "@/hooks/useNotify";
 import { useOllamaStore } from "@/features/ollama/monitor";
 import { buildSystemPrompt } from "@/lib/chat/prompts";
@@ -52,6 +52,7 @@ async function enqueueMemoryProcessing(conversationId: string, assistantMessageI
         userMessageId: userMessage.id,
         assistantMessageId,
       },
+      token: getSessionToken(),
     });
   } catch (error) {
     console.warn("[Memory] Completed turn enqueue skipped", error);
@@ -285,6 +286,7 @@ export function useChatStream(modelChoices: ModelChoice[], systemPrompt = "") {
               providerType: provider,
               providerConfigId: providerConfigId ?? null,
               accountId: getCurrentProviderAccountId(),
+              token: getSessionToken(),
             });
           } catch (err) {
             const errMsg = typeof err === "string" ? err : (err as Error).message || "Unknown error";

--- a/src/features/memory/memoryClient.ts
+++ b/src/features/memory/memoryClient.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { getSessionToken } from "@/lib/utils/utils";
 import type {
   MemoryForgetMessageInput,
   MemoryListQuery,
@@ -10,26 +11,26 @@ import type {
 } from "./types";
 
 export function memoryGetSettings(ownerId: string) {
-  return invoke<MemorySettings>("memory_get_settings", { ownerId });
+  return invoke<MemorySettings>("memory_get_settings", { ownerId, token: getSessionToken() });
 }
 
 export function memoryUpdateSettings(settings: MemorySettings) {
-  return invoke<MemorySettings>("memory_update_settings", { settings });
+  return invoke<MemorySettings>("memory_update_settings", { settings, token: getSessionToken() });
 }
 
 export function memoryTestConnection(ownerId: string) {
   return invoke<{ ok: boolean; provider: string; locality: string; message: string }>(
     "memory_test_connection",
-    { ownerId },
+    { ownerId, token: getSessionToken() },
   );
 }
 
 export function memoryList(query: MemoryListQuery) {
-  return invoke<MemoryRecord[]>("memory_list", { query });
+  return invoke<MemoryRecord[]>("memory_list", { query, token: getSessionToken() });
 }
 
 export function memorySearch(query: MemorySearchQuery) {
-  return invoke<MemoryRecord[]>("memory_search", { query });
+  return invoke<MemoryRecord[]>("memory_search", { query, token: getSessionToken() });
 }
 
 export function memoryUpdate(input: {
@@ -42,32 +43,38 @@ export function memoryUpdate(input: {
   confidence?: number | null;
   importance?: number | null;
 }) {
-  return invoke<MemoryRecord>("memory_update", { input });
+  return invoke<MemoryRecord>("memory_update", { input, token: getSessionToken() });
 }
 
 export function memoryDelete(ownerId: string, memoryId: string) {
-  return invoke<void>("memory_delete", { ownerId, memoryId });
+  return invoke<void>("memory_delete", { ownerId, memoryId, token: getSessionToken() });
 }
 
 export function memoryClearScope(ownerId: string, scope: MemoryScope, scopeOwnerId?: string | null) {
-  return invoke<void>("memory_clear_scope", { ownerId, scope, scopeOwnerId: scopeOwnerId ?? null });
+  return invoke<void>("memory_clear_scope", {
+    ownerId,
+    scope,
+    scopeOwnerId: scopeOwnerId ?? null,
+    token: getSessionToken(),
+  });
 }
 
 export function memoryClearAll(ownerId: string) {
-  return invoke<void>("memory_clear_all", { ownerId });
+  return invoke<void>("memory_clear_all", { ownerId, token: getSessionToken() });
 }
 
 export function memoryRememberMessage(input: MemoryRememberMessageInput) {
-  return invoke("memory_remember_message", { input });
+  return invoke("memory_remember_message", { input, token: getSessionToken() });
 }
 
 export function memoryForgetMessage(input: MemoryForgetMessageInput) {
-  return invoke<void>("memory_forget_message", { input });
+  return invoke<void>("memory_forget_message", { input, token: getSessionToken() });
 }
 
 export function memoryGetRelated(ownerId: string, messageId: string, query: string) {
   return invoke<MemoryRecord[]>("memory_get_related", {
     query: { ownerId, messageId, query, limit: 8 },
+    token: getSessionToken(),
   });
 }
 

--- a/src/features/ollama/client.ts
+++ b/src/features/ollama/client.ts
@@ -1,4 +1,4 @@
-import { loggedInvoke } from "@/lib/utils/utils";
+import { loggedInvoke, getSessionToken } from "@/lib/utils/utils";
 import type { OllamaModel } from "./types";
 
 import type {
@@ -22,6 +22,7 @@ export const ollamaClient = {
   async getProviderAndModels(): Promise<ProviderAndModelsResult> {
     return loggedInvoke<ProviderAndModelsResult>("get_provider_and_models", {
       accountId: getCurrentProviderAccountId(),
+      token: getSessionToken(),
     });
   },
 
@@ -29,6 +30,7 @@ export const ollamaClient = {
     return loggedInvoke<OllamaModel[]>("get_provider_models", {
       providerType,
       accountId: getCurrentProviderAccountId(),
+      token: getSessionToken(),
     });
   },
 

--- a/src/features/providers/index.ts
+++ b/src/features/providers/index.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { create } from "zustand";
 import { useAuthStore } from "@/store/authStore";
+import { getSessionToken } from "@/lib/utils/utils";
 
 export type ProviderType = "OllamaLocal" | "OpenAICompatible";
 export type ProviderStatus = "Online" | "Offline" | "Reconnecting" | "Unavailable";
@@ -80,6 +81,7 @@ export const useProviderStore = create<ProviderStore>((set) => ({
       try {
         const providers = await invoke<ProviderStatusResponse[]>("get_providers", {
           accountId: getCurrentProviderAccountId(),
+          token: getSessionToken(),
         });
         set({ providers, loading: false, error: null });
       } catch (err) {
@@ -106,35 +108,43 @@ export const useProviderStore = create<ProviderStore>((set) => ({
       model_suggestions?: string;
     }) => {
       const accountId = getCurrentProviderAccountId();
+      const token = getSessionToken();
       const current = (await invoke<ProviderStatusResponse[]>("get_providers", {
         accountId,
+        token,
       })).find((p) => p.config.id === config.id);
       if (!current) throw new Error("Provider not found");
       await invoke("update_provider_config", {
         request: { ...current.config, ...config },
         accountId,
+        token,
       });
       set({ loading: true });
       const providers = await invoke<ProviderStatusResponse[]>("get_providers", {
         accountId,
+        token,
       });
       set({ providers, loading: false, error: null });
     },
     addProvider: async (config: AddProviderRequest) => {
       const accountId = getCurrentProviderAccountId();
-      await invoke("add_provider", { request: config, accountId });
+      const token = getSessionToken();
+      await invoke("add_provider", { request: config, accountId, token });
       set({ loading: true });
       const providers = await invoke<ProviderStatusResponse[]>("get_providers", {
         accountId,
+        token,
       });
       set({ providers, loading: false, error: null });
     },
     deleteProvider: async (id: number) => {
       const accountId = getCurrentProviderAccountId();
-      await invoke("delete_provider", { id, accountId });
+      const token = getSessionToken();
+      await invoke("delete_provider", { id, accountId, token });
       set({ loading: true });
       const providers = await invoke<ProviderStatusResponse[]>("get_providers", {
         accountId,
+        token,
       });
       set({ providers, loading: false, error: null });
     },

--- a/src/lib/chat/title-generation.ts
+++ b/src/lib/chat/title-generation.ts
@@ -1,4 +1,4 @@
-import { loggedInvoke } from "@/lib/utils/utils";
+import { loggedInvoke, getSessionToken } from "@/lib/utils/utils";
 import type { ChatMessage } from "@/types/chat";
 import type { ModelProvider } from "@/store/modelStore";
 import { getCurrentProviderAccountId } from "@/features/providers";
@@ -246,6 +246,7 @@ async function generateAndApplyTitle(
       userName,
       providerType,
       accountId: getCurrentProviderAccountId(),
+      token: getSessionToken(),
     });
   } catch (err) {
     console.warn("Title generation invoke failed", err);

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -6,6 +6,14 @@ export async function loggedInvoke<T>(cmd: string, args: InvokeArgs = {}): Promi
   return invoke<T>(cmd, args);
 }
 
+export function getSessionToken(): string | null {
+  try {
+    return localStorage.getItem("session_token");
+  } catch {
+    return null;
+  }
+}
+
 export function isImageAttachment(type: string): boolean {
   return type.startsWith("image/");
 }


### PR DESCRIPTION
## Summary
- A security audit found that `memory_*`, `provider_*`, and `chat_stream`/`chat`/`generate_chat_title` Tauri commands trusted a client-supplied `account_id`/`owner_id` with no server-side check that the calling session actually owned that account — unlike `auth_update_profile`, `auth_change_password`, etc., which already derive the user from a validated session token.
- Since user IDs are sequential integers (not UUIDs), this allowed any code running in the webview to read/modify another local account's conversations, memories, and stored provider API keys by simply supplying their numeric ID.
- Adds `authorize_account()` in `auth.rs`: registered accounts now require a session token that resolves to the same user ID. Guest IDs (client-generated, never written to the `users` table) pass through unchanged since they have no server-side account to protect.
- Wires the check into the affected commands and threads the session token through from the frontend call sites.

## Test plan
- [x] `cargo check` — clean build
- [x] `cargo test` — 74 passed, 0 failed
- [x] `tsc --noEmit` — clean
- [x] `bun test` — 72 passed, 0 failed
- [ ] Manual smoke test of login, guest mode, chat streaming, and memory settings in the running app


---
_Generated by [Claude Code](https://claude.ai/code/session_014waqJJdrWpsBa2YvQ8ck3g)_