### PR TITLE
fix: settings modal perf, unstyled dialogs, sheet z-index, sidebar pa…

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -37,7 +37,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/30 duration-[var(--dur-fast)] supports-backdrop-filter:backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 z-[var(--z-modal)] bg-black/30 duration-[var(--dur-fast)] supports-backdrop-filter:backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}
@@ -62,7 +62,7 @@ function SheetContent({
         data-slot="sheet-content"
         data-side={side}
         className={cn(
-          "fixed z-50 flex flex-col bg-popover bg-clip-padding text-sm text-popover-foreground shadow-xl transition duration-[var(--dur-base)] ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+          "fixed z-[var(--z-modal)] flex flex-col bg-popover bg-clip-padding text-sm text-popover-foreground shadow-xl transition duration-[var(--dur-base)] ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
           className
         )}
         {...props}

--- a/src/features/dictation/DictationModelDialog.tsx
+++ b/src/features/dictation/DictationModelDialog.tsx
@@ -8,6 +8,7 @@ import { DialogTitle } from "@/components/ui/dialog-panel";
 import { LinearProgress } from "@/components/ui/linear-progress";
 import { Stack } from "@/components/ui/Stack";
 import { Typography } from "@/components/ui/Typography";
+import { cn } from "@/lib/utils";
 import type { WhisperModelInfo } from "@/hooks/useDictation";
 
 interface DictationModelDialogProps {
@@ -40,7 +41,7 @@ export function DictationModelDialog({
     >
       <DialogTitle>Install dictation model</DialogTitle>
       <DialogContent>
-        <Typography variant="body2">
+        <Typography variant="body2" color="muted" className="mb-4">
           Dictation runs locally. Choose a Whisper model to download before recording.
         </Typography>
 
@@ -53,13 +54,14 @@ export function DictationModelDialog({
             return (
               <Box
                 key={model.id}
-                className={selected ? "border-primary" : undefined}
+                className={cn(
+                  "rounded-xl border border-border/60 p-3",
+                  selected && "border-primary",
+                )}
               >
-                <Box
-                >
-                  <Box>
-                    <Box
-                    >
+                <Box className="flex items-start justify-between gap-3">
+                  <Box className="min-w-0 flex-1">
+                    <Box className="flex flex-wrap items-center gap-1.5">
                       <Typography variant="subtitle2">
                         {model.name}
                       </Typography>
@@ -75,14 +77,10 @@ export function DictationModelDialog({
                         <Chip label="Installed" size="small" />
                       )}
                     </Box>
-                    <Typography
-                      variant="body2"
-                    >
+                    <Typography variant="body2" color="muted" className="mt-0.5">
                       {model.description}
                     </Typography>
-                    <Typography
-                      variant="caption"
-                    >
+                    <Typography variant="caption" color="muted" className="mt-1 block">
                       {model.sizeLabel} / {model.speedLabel} /{" "}
                       {model.qualityLabel}
                     </Typography>
@@ -103,7 +101,7 @@ export function DictationModelDialog({
                 </Box>
 
                 {installing && (
-                  <Box>
+                  <Box className="mt-3">
                     <LinearProgress
                       variant={
                         downloadPercent === null
@@ -112,9 +110,7 @@ export function DictationModelDialog({
                       }
                       value={downloadPercent ?? undefined}
                     />
-                    <Typography
-                      variant="caption"
-                    >
+                    <Typography variant="caption" color="muted" className="mt-1 block">
                       {downloadPercent === null
                         ? "Starting download..."
                         : `${downloadPercent}% downloaded`}

--- a/src/features/release-notes/ReleaseNotesModal.tsx
+++ b/src/features/release-notes/ReleaseNotesModal.tsx
@@ -32,67 +32,59 @@ export function ReleaseNotesModal() {
       showCloseButton={false}
     >
       {show && (
-        <Box>
-          <Box>  
-              <Box>
-                <IconButton
-                  onClick={dismiss}
-                  size="small"
-                  aria-label="Close"
-                >
-                  <X size={18} />
-                </IconButton>
+        <Box className="relative flex max-h-[70vh] flex-col gap-4 p-6">
+          <IconButton
+            onClick={dismiss}
+            size="small"
+            aria-label="Close"
+            className="absolute top-4 right-4"
+          >
+            <X size={18} />
+          </IconButton>
 
-                <Box>
-                  <Stack direction="row" spacing={1.5} alignItems="center">
-                    <Box
-                    >
-                      <Sparkles size={18} />
-                    </Box>
-                    <Box>
-                      <Typography>
-                        What's new in Poly UI
-                      </Typography>
-                      {version && (
-                        <Typography>
-                          v{version}
-                        </Typography>
-                      )}
-                    </Box>
-                  </Stack>
-                </Box>
-
-                <Box
-                >
-                  {loading ? (
-                    <LoadingState />
-                  ) : data?.ok ? (
-                    <MarkdownProse content={data.body} />
-                  ) : (
-                    <FallbackState version={version} data={data} />
-                  )}
-                </Box>
-
-                <Box
-                >
-                  {data?.ok && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => window.open((data as Extract<typeof data, { ok: true }>).htmlUrl, "_blank")}
-                    >
-                      <ExternalLink size={14} />
-                      View on GitHub
-                    </Button>
-                  )}
-                  <Button variant="default" size="sm" onClick={dismiss}>
-                    Got it
-                  </Button>
-                </Box>
-              </Box>
+          <Stack direction="row" spacing={1.5} alignItems="center">
+            <Box className="grid size-9 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary">
+              <Sparkles size={18} />
             </Box>
+            <Box>
+              <Typography variant="subtitle1">
+                What's new in Poly UI
+              </Typography>
+              {version && (
+                <Typography variant="caption" color="muted">
+                  v{version}
+                </Typography>
+              )}
+            </Box>
+          </Stack>
+
+          <Box className="min-h-0 flex-1 overflow-y-auto pr-1">
+            {loading ? (
+              <LoadingState />
+            ) : data?.ok ? (
+              <MarkdownProse content={data.body} />
+            ) : (
+              <FallbackState version={version} data={data} />
+            )}
           </Box>
-        )}
+
+          <Box className="flex items-center justify-end gap-2 border-t border-border/60 pt-4">
+            {data?.ok && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => window.open((data as Extract<typeof data, { ok: true }>).htmlUrl, "_blank")}
+              >
+                <ExternalLink size={14} />
+                View on GitHub
+              </Button>
+            )}
+            <Button variant="default" size="sm" onClick={dismiss}>
+              Got it
+            </Button>
+          </Box>
+        </Box>
+      )}
     </Modal>
   );
 }
@@ -105,6 +97,7 @@ function LoadingState() {
       {widths.map((width, i) => (
         <Box
           key={i}
+          className="h-3.5 animate-pulse rounded-full bg-muted"
           style={{ width }}
         />
       ))}
@@ -120,11 +113,11 @@ function FallbackState({
   data: ReleaseNotesResult | null;
 }) {
   return (
-    <Box>
-      <Typography>
+    <Box className="flex flex-col gap-1">
+      <Typography variant="subtitle2">
         {version ? `Poly UI v${version}` : "Poly UI"}
       </Typography>
-      <Typography>
+      <Typography variant="body2" color="muted">
         {data === null
           ? "Release notes could not be loaded right now."
           : "No release notes available for this version."}

--- a/src/features/settings/SettingsModal.tsx
+++ b/src/features/settings/SettingsModal.tsx
@@ -120,7 +120,7 @@ function SettingsNavButton({
 
 export function SettingsModal({ isOpen, onClose, initialTab = "general" }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<SettingsTab>(initialTab);
-  const [allMounted, setAllMounted] = useState(false);
+  const [visitedTabs, setVisitedTabs] = useState<Set<SettingsTab>>(() => new Set([initialTab]));
   const devMode = useDevStore((s) => s.devMode);
   const experimentalEnabled = useSettingsStore((state) => state.general.experimentalFeatures);
   const sidebarItems = devMode
@@ -134,24 +134,23 @@ export function SettingsModal({ isOpen, onClose, initialTab = "general" }: Setti
   const activeItem = [...sidebarItems, ADVANCED_ITEM].find((item) => item.id === activeTab);
   const panelItems = [...sidebarItems, ADVANCED_ITEM];
 
+  const selectTab = (tab: SettingsTab) => {
+    setActiveTab(tab);
+    setVisitedTabs((prev) => (prev.has(tab) ? prev : new Set(prev).add(tab)));
+  };
+
   useEffect(() => {
     if (!isOpen) return;
     const validIds = new Set([...sidebarItems, ADVANCED_ITEM].map((i) => i.id));
-    if (validIds.has(initialTab)) {
-      setActiveTab(initialTab);
-    } else {
-      setActiveTab(sidebarItems[0]?.id ?? "general");
-    }
+    const nextTab = validIds.has(initialTab) ? initialTab : (sidebarItems[0]?.id ?? "general");
+    selectTab(nextTab);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialTab, isOpen]);
 
   useEffect(() => {
-    if (!experimentalEnabled && activeTab === "memory") setActiveTab("advanced");
+    if (!experimentalEnabled && activeTab === "memory") selectTab("advanced");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab, experimentalEnabled]);
-
-  useEffect(() => {
-    const frame = requestAnimationFrame(() => setAllMounted(true));
-    return () => cancelAnimationFrame(frame);
-  }, []);
 
   return (
     <AppDialogFrame open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -171,7 +170,7 @@ export function SettingsModal({ isOpen, onClose, initialTab = "general" }: Setti
                   key={item.id}
                   item={item}
                   isActive={isActive}
-                  onClick={() => setActiveTab(item.id)}
+                  onClick={() => selectTab(item.id)}
                 />
               );
             })}
@@ -182,7 +181,7 @@ export function SettingsModal({ isOpen, onClose, initialTab = "general" }: Setti
               const isActive = activeTab === ADVANCED_ITEM.id;
               return (
                 <SettingsNavButton
-                  onClick={() => setActiveTab(ADVANCED_ITEM.id)}
+                  onClick={() => selectTab(ADVANCED_ITEM.id)}
                   item={ADVANCED_ITEM}
                   isActive={isActive}
                 />
@@ -210,7 +209,7 @@ export function SettingsModal({ isOpen, onClose, initialTab = "general" }: Setti
                   item={item}
                   isActive={isActive}
                   mobile
-                  onClick={() => setActiveTab(item.id)}
+                  onClick={() => selectTab(item.id)}
                 />
               );
             })}
@@ -219,15 +218,15 @@ export function SettingsModal({ isOpen, onClose, initialTab = "general" }: Setti
           <AppDialogBody>
             <Box className="min-h-[400px] w-full">
               <Box className={activeTab !== "general" ? "hidden" : ""}><GeneralTab /></Box>
-              {(allMounted || activeTab === "profile") && <Box className={activeTab !== "profile" ? "hidden" : ""}><ProfileTab /></Box>}
-              {(allMounted || activeTab === "connections") && <Box className={activeTab !== "connections" ? "hidden" : ""}><ConnectionsTab /></Box>}
-              {(allMounted || activeTab === "personalisation") && <Box className={activeTab !== "personalisation" ? "hidden" : ""}><PersonalisationTab /></Box>}
-              {(allMounted || activeTab === "speech") && <Box className={activeTab !== "speech" ? "hidden" : ""}><SpeechTab /></Box>}
-              {(allMounted || activeTab === "data-controls") && <Box className={activeTab !== "data-controls" ? "hidden" : ""}><DataControlsTab /></Box>}
-              {(allMounted || activeTab === "about") && <Box className={activeTab !== "about" ? "hidden" : ""}><AboutTab /></Box>}
-              {experimentalEnabled && (allMounted || activeTab === "memory") && <Box className={activeTab !== "memory" ? "hidden" : ""}><MemoryTab /></Box>}
-              {(allMounted || activeTab === "advanced") && <Box className={activeTab !== "advanced" ? "hidden" : ""}><AdvancedTab /></Box>}
-              {(allMounted || activeTab === "developer") && <Box className={activeTab !== "developer" ? "hidden" : ""}><DeveloperTab onClose={onClose} /></Box>}
+              {visitedTabs.has("profile") && <Box className={activeTab !== "profile" ? "hidden" : ""}><ProfileTab /></Box>}
+              {visitedTabs.has("connections") && <Box className={activeTab !== "connections" ? "hidden" : ""}><ConnectionsTab /></Box>}
+              {visitedTabs.has("personalisation") && <Box className={activeTab !== "personalisation" ? "hidden" : ""}><PersonalisationTab /></Box>}
+              {visitedTabs.has("speech") && <Box className={activeTab !== "speech" ? "hidden" : ""}><SpeechTab /></Box>}
+              {visitedTabs.has("data-controls") && <Box className={activeTab !== "data-controls" ? "hidden" : ""}><DataControlsTab /></Box>}
+              {visitedTabs.has("about") && <Box className={activeTab !== "about" ? "hidden" : ""}><AboutTab /></Box>}
+              {experimentalEnabled && visitedTabs.has("memory") && <Box className={activeTab !== "memory" ? "hidden" : ""}><MemoryTab /></Box>}
+              {visitedTabs.has("advanced") && <Box className={activeTab !== "advanced" ? "hidden" : ""}><AdvancedTab /></Box>}
+              {visitedTabs.has("developer") && <Box className={activeTab !== "developer" ? "hidden" : ""}><DeveloperTab onClose={onClose} /></Box>}
             </Box>
           </AppDialogBody>
         </Box>

--- a/src/features/sidebar/constants.ts
+++ b/src/features/sidebar/constants.ts
@@ -10,7 +10,7 @@ export const SIDEBAR_TOKENS = {
   expandedWidth: "17rem", // ~272px, within the 260–280px target
   collapsedWidth: "4rem", // 64px
   mobileWidth: "18rem",
-  sidebarPadding: "0.375rem", // 6px
+  sidebarPadding: "0.625rem", // 10px
   itemHeight: "2.5rem", // 40px nav/folder/chat rows
   iconButtonSize: "2.25rem", // 36px collapsed icon hitbox
   iconSize: "1.125rem", // 18px


### PR DESCRIPTION
…dding

- SettingsModal: mount tabs lazily on first visit instead of force-mounting all 9 tabs via rAF on open, which was blocking the main thread and firing every tab's mount effects (incl. IPC calls) at once on first open
- ReleaseNotesModal, DictationModelDialog: post-Shadcn-migration leftovers had bare <Box>/<Typography> with no className, rendering as unstyled div soup; added proper layout/spacing classes
- sheet.tsx: hardcoded z-50 -> z-[var(--z-modal)] to match dialog.tsx and keep overlay stacking consistent
- sidebar constants: bump sidebarPadding token 6px -> 10px for more breathing room