### PR TITLE
fix(chat): streaming and queue bugs from audit

### DIFF
--- a/src-tauri/src/tool_loop.rs
+++ b/src-tauri/src/tool_loop.rs
@@ -208,6 +208,7 @@ impl ToolLoop {
                 .map_err(|e| AppError::Provider(format!("Generation failed: {e}")))?;
 
             let mut tool_calls_opt: Option<Vec<ToolCallInfo>> = None;
+            let mut restart_for_tool_call = false;
 
             while let Some(result) = stream.next().await {
                 if is_cancelled() {
@@ -251,6 +252,8 @@ impl ToolLoop {
                     tool_calls_opt = Some(tcs);
                 }
 
+                // Thinking events carry the full accumulated text (O(n²) IPC, but
+                // self-healing: a dropped event can't corrupt the disclosure)
                 if let Some(tc) = chunk.thinking.as_ref().filter(|tc| !tc.is_empty()) {
                     thinking_acc.push_str(tc);
                     emitter
@@ -392,6 +395,7 @@ impl ToolLoop {
                             thinking_acc.clear();
                             final_metadata = None;
                             thinking_parser = ThinkingTagParser::new(reasoning_enabled);
+                            restart_for_tool_call = true;
                             break;
                         }
                     }
@@ -422,6 +426,25 @@ impl ToolLoop {
                         metadata: final_metadata,
                     });
                 }
+            }
+
+            // Stream exhausted without a done marker (connection dropped) and no
+            // tool call requested a restart — finalize instead of re-issuing the
+            // same request forever.
+            if !restart_for_tool_call {
+                let err = "Stream ended unexpectedly".to_string();
+                emitter
+                    .emit_chunk(&StreamPayload {
+                        request_id: request_id.to_string(),
+                        content: String::new(),
+                        thinking: None,
+                        done: true,
+                        metadata: final_metadata.clone(),
+                        tool_calls: None,
+                        error: Some(err.clone()),
+                    })
+                    .await;
+                return Err(AppError::Provider(err));
             }
         }
     }

--- a/src/features/chat/components/Message/hooks.tsx
+++ b/src/features/chat/components/Message/hooks.tsx
@@ -1,36 +1,12 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { useTtsStore } from "@/store/ttsStore";
 import { useNotify } from "@/hooks/useNotify";
 import { stripInvisible } from "./utils";
 
 export function useMessageStreaming(content: string, isStreaming?: boolean) {
-  const pendingMarkdownRef = useRef<number | null>(null);
-  const lastMarkdownContentRef = useRef("");
-  const [streamingDisplayContent, setStreamingDisplayContent] = useState("");
-
-  useEffect(() => {
-    if (!isStreaming || !content) {
-      setStreamingDisplayContent("");
-      return;
-    }
-    if (content === lastMarkdownContentRef.current) return;
-    lastMarkdownContentRef.current = content;
-    if (pendingMarkdownRef.current !== null) {
-      cancelAnimationFrame(pendingMarkdownRef.current);
-    }
-    pendingMarkdownRef.current = requestAnimationFrame(() => {
-      pendingMarkdownRef.current = null;
-      setStreamingDisplayContent(content);
-    });
-    return () => {
-      if (pendingMarkdownRef.current !== null) {
-        cancelAnimationFrame(pendingMarkdownRef.current);
-        pendingMarkdownRef.current = null;
-      }
-    };
-  }, [content, isStreaming]);
-
-  return streamingDisplayContent;
+  // Content updates are already rAF-batched by StreamAccumulator — a second
+  // rAF buffer here only added a frame of latency per token flush.
+  return isStreaming && content ? content : "";
 }
 
 export function useMessageMarkdown(content: string, thinking?: string, isStreaming?: boolean) {

--- a/src/features/chat/hooks/useChatStream.ts
+++ b/src/features/chat/hooks/useChatStream.ts
@@ -25,6 +25,7 @@ import {
   type WebSearchPayload,
 } from "@/lib/chat/event-bus";
 import { StreamSession } from "@/lib/chat/stream-session";
+import { getRepository } from "@/lib/repositories";
 import { getWebSearchConfig } from "@/features/web-search/useWebSearchConfig";
 import { getCurrentProviderAccountId } from "@/features/providers";
 import { useSettingsStore } from "@/store/settingsStore";
@@ -190,6 +191,8 @@ export function useChatStream(modelChoices: ModelChoice[], systemPrompt = "") {
       settlePending(completed.requestId);
 
       if (sessionRef.current.isComplete()) {
+        // Turn is over — drop pending memories so a later regenerate doesn't re-attach them
+        pendingMemoryUpdates.delete(completed.conversationId);
         if (completedModel && !completed.error) triggerTitleGeneration(titleStore, completed.conversationId);
         processNextInQueueRef.current?.(completed.conversationId);
       }
@@ -242,12 +245,18 @@ export function useChatStream(modelChoices: ModelChoice[], systemPrompt = "") {
   }, []);
 
   const startStream = useCallback(
-    (conversationId: string, models: ModelChoice[]) => {
+    async (conversationId: string, models: ModelChoice[]) => {
       if (!conversationId || !models.length) return;
 
-      const history = useChatStore.getState().messages
-        .filter((m) => m.conversationId === conversationId)
-        .map((m) => ({
+      // Store only holds the active conversation's messages. Queued sends can
+      // target a background conversation — load its history from the repository
+      // (temporary chats aren't persisted, but they're only usable while active).
+      const { messages: storeMessages, activeConversationId: activeId } = useChatStore.getState();
+      const source =
+        conversationId === activeId
+          ? storeMessages.filter((m) => m.conversationId === conversationId)
+          : await getRepository().getMessages(conversationId, 50, 0);
+      const history = source.map((m) => ({
           role: m.role,
           content: m.content,
           attachments: m.attachments ?? [],
@@ -327,7 +336,10 @@ export function useChatStream(modelChoices: ModelChoice[], systemPrompt = "") {
     const conversationId = completedConversationId ?? activeConversationIdRef.current;
     if (!conversationId) return;
 
-    const next = useChatStore.getState().actions.getNextQueued(conversationId);
+    // Prefer the completed conversation's queue, but fall back to any queued
+    // message — otherwise sends queued from another conversation starve.
+    const store = useChatStore.getState();
+    const next = store.actions.getNextQueued(conversationId) ?? store.messageQueue[0];
     if (!next) return;
 
     processingQueueRef.current = true;
@@ -347,7 +359,7 @@ export function useChatStream(modelChoices: ModelChoice[], systemPrompt = "") {
       });
       void extractUserMessageMemory(next.conversationId, userMessageId);
 
-      startStream(next.conversationId, models);
+      await startStream(next.conversationId, models);
     } catch (err) {
       console.error("processNextInQueue failed — message may be lost", err);
     } finally {
@@ -395,7 +407,7 @@ export function useChatStream(modelChoices: ModelChoice[], systemPrompt = "") {
       });
       void extractUserMessageMemory(conversationId, userMessageId);
 
-      startStream(conversationId, models);
+      await startStream(conversationId, models);
     },
     [modelChoices, isStreaming, activeConversationId, addMessage, startStream],
   );
@@ -418,18 +430,14 @@ export function useChatStream(modelChoices: ModelChoice[], systemPrompt = "") {
         ...msg,
         content: sanitizeOutput(msg.content || ""),
         isThinking: false,
+        isStreaming: false,
         thinkingDuration: sessionRef.current.thinkingDuration(rid),
         status: "aborted",
       });
       setStreamingMessage(mid, null);
     }
 
-    const queueConversationId =
-      useChatStore.getState().streamingConversationId ??
-      activeConversationIdRef.current;
-    if (queueConversationId) {
-      clearQueue(queueConversationId);
-    }
+    clearQueue();
     resetStreamState();
     setIsStreaming(false);
     setStreamingConversationId(null);
@@ -439,7 +447,7 @@ export function useChatStream(modelChoices: ModelChoice[], systemPrompt = "") {
     (conversationId: string) => {
       const models = validModelChoices(modelChoices);
       if (isStreaming || !models.length || !conversationId) return;
-      startStream(conversationId, models);
+      void startStream(conversationId, models);
     },
     [modelChoices, isStreaming, startStream],
   );

--- a/src/lib/chat/sanitize.ts
+++ b/src/lib/chat/sanitize.ts
@@ -5,7 +5,8 @@ const FIM_PATTERNS = [
 
 const TOOL_LEAK_PATTERNS = [
   /commentary\s+to=functions\.\w+/gi,
-  /<\|?(?:assistant|system|user|tool)(?:\|[^\n>]*)?>?/gi,
+  // require the template pipe (<|user|>) so legit markup like <user> in code survives
+  /<\|(?:assistant|system|user|tool)(?:\|[^\n>]*)?>?/gi,
   /<!--\s*(?:Assistant|System|Tool)\s+(?:greeting|instruction|note).*?-->/gi,
 ];
 
@@ -26,7 +27,9 @@ export function sanitizeOutput(text: string): string {
 
   result = result.trim();
 
-  if (!result || result.length < 10) {
+  // Fall back only when sanitization gutted a non-empty response —
+  // short legit answers ("4", "Yes.") must pass through untouched.
+  if (!result && text.trim()) {
     return FALLBACK_TEXT;
   }
 

--- a/src/lib/chat/stream-accumulator.ts
+++ b/src/lib/chat/stream-accumulator.ts
@@ -56,16 +56,18 @@ export class StreamAccumulator {
   }
 
   reset(requestIds?: string[]) {
-    this.disposed = false;
     if (requestIds) {
+      // Partial reset: one stream finished (its updates already force-flushed).
+      // Leave pending/rAF alone — sibling streams may have a flush in flight.
       for (const rid of requestIds) {
         delete this.content[rid];
         delete this.thinking[rid];
       }
-    } else {
-      this.content = {};
-      this.thinking = {};
+      return;
     }
+    this.disposed = false;
+    this.content = {};
+    this.thinking = {};
     if (this.flushRaf !== null) cancelAnimationFrame(this.flushRaf);
     this.flushRaf = null;
     this.hasScheduledFlush = false;

--- a/src/lib/chat/stream-session.ts
+++ b/src/lib/chat/stream-session.ts
@@ -27,6 +27,7 @@ export class StreamSession {
   private requestIdToMessageId: Record<string, string> = {};
   private requestIdToConversationId: Record<string, string> = {};
   private thinkingStartTime: Record<string, number> = {};
+  private thinkingEndTime: Record<string, number> = {};
   private pendingStreams = 0;
   private cancelled = false;
 
@@ -84,9 +85,18 @@ export class StreamSession {
     const messageId = this.requestIdToMessageId[payload.request_id];
     if (!messageId) return null;
 
+    // Backend sends full accumulated thinking each event — replace, don't append
     this.accumulator.thinking[payload.request_id] = payload.thinking;
     if (payload.is_thinking && !this.thinkingStartTime[payload.request_id]) {
       this.thinkingStartTime[payload.request_id] = Date.now();
+    }
+    // Capture when thinking stops — duration must not include answer generation
+    if (
+      !payload.is_thinking &&
+      this.thinkingStartTime[payload.request_id] &&
+      !this.thinkingEndTime[payload.request_id]
+    ) {
+      this.thinkingEndTime[payload.request_id] = Date.now();
     }
 
     return {
@@ -125,6 +135,9 @@ export class StreamSession {
   }
 
   finish(requestId: string) {
+    // Idempotent: error paths can settle the same request twice (done-chunk with
+    // error + rejected invoke). A second finish must not decrement pendingStreams.
+    if (!(requestId in this.requestIdToMessageId)) return this.pendingStreams;
     delete this.requestIdToMessageId[requestId];
     delete this.requestIdToConversationId[requestId];
     this.accumulator.reset([requestId]);
@@ -141,6 +154,7 @@ export class StreamSession {
     this.requestIdToMessageId = {};
     this.requestIdToConversationId = {};
     this.thinkingStartTime = {};
+    this.thinkingEndTime = {};
     this.pendingStreams = 0;
     this.cancelled = true;
   }
@@ -150,6 +164,7 @@ export class StreamSession {
     this.requestIdToMessageId = {};
     this.requestIdToConversationId = {};
     this.thinkingStartTime = {};
+    this.thinkingEndTime = {};
     this.pendingStreams = 0;
     this.cancelled = false;
   }
@@ -173,6 +188,7 @@ export class StreamSession {
   thinkingDuration(requestId?: string) {
     if (!requestId) return undefined;
     const startedAt = this.thinkingStartTime[requestId];
-    return startedAt ? (Date.now() - startedAt) / 1000 : undefined;
+    if (!startedAt) return undefined;
+    return ((this.thinkingEndTime[requestId] ?? Date.now()) - startedAt) / 1000;
   }
 }

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -85,7 +85,7 @@ type ChatStore = {
     clearCurrentAttachments: () => void;
     enqueueMessage: (msg: QueuedMessage) => void;
     dequeueMessage: (id: string) => void;
-    clearQueue: (conversationId: string) => void;
+    clearQueue: () => void;
     getNextQueued: (conversationId: string) => QueuedMessage | undefined;
     clearFolderAssignments: (folderIds: Set<string>) => void;
   };
@@ -427,12 +427,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       set((state) => ({
         messageQueue: state.messageQueue.filter((m) => m.id !== id),
       })),
-    clearQueue: (conversationId) =>
-      set((state) => ({
-        messageQueue: state.messageQueue.filter(
-          (m) => m.conversationId !== conversationId,
-        ),
-      })),
+    // Stop kills the whole session, so no queued message anywhere should fire later
+    clearQueue: () => set({ messageQueue: [] }),
     getNextQueued: (conversationId) => {
       return getNextQueuedMessage(get().messageQueue, conversationId);
     },

--- a/tests/chatStreamFixes.test.ts
+++ b/tests/chatStreamFixes.test.ts
@@ -1,0 +1,86 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { sanitizeOutput } from "@/lib/chat/sanitize";
+import { StreamSession } from "@/lib/chat/stream-session";
+import { StreamAccumulator } from "@/lib/chat/stream-accumulator";
+
+beforeAll(() => {
+  // Node env has no rAF; accumulator schedules flushes with it
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+});
+
+describe("sanitizeOutput", () => {
+  it("passes short legit answers through untouched", () => {
+    expect(sanitizeOutput("4")).toBe("4");
+    expect(sanitizeOutput("Yes.")).toBe("Yes.");
+  });
+
+  it("still falls back when sanitization guts the response", () => {
+    expect(sanitizeOutput("<|assistant|>")).toMatch(/formatting issue/);
+  });
+
+  it("strips chat-template tokens but keeps legit markup", () => {
+    expect(sanitizeOutput("Use <user> tags in your XML schema")).toBe(
+      "Use <user> tags in your XML schema",
+    );
+    expect(sanitizeOutput("Hello <|user|> world")).toBe("Hello  world");
+  });
+});
+
+describe("StreamSession", () => {
+  function makeSession() {
+    const session = new StreamSession();
+    session.start(1);
+    session.register({ requestId: "r1", messageId: "m1", conversationId: "c1" });
+    return session;
+  }
+
+  it("thinking duration excludes answer generation time", () => {
+    vi.useFakeTimers();
+    const session = makeSession();
+    session.applyThinking({ request_id: "r1", thinking: "hmm", is_thinking: true });
+    vi.advanceTimersByTime(3000);
+    session.applyThinking({ request_id: "r1", thinking: " done", is_thinking: false });
+    vi.advanceTimersByTime(60000); // long answer afterwards
+    expect(session.thinkingDuration("r1")).toBe(3);
+    vi.useRealTimers();
+  });
+
+  it("thinking events carry full text — latest payload wins, no duplication", () => {
+    const session = makeSession();
+    session.applyThinking({ request_id: "r1", thinking: "a", is_thinking: true });
+    const update = session.applyThinking({ request_id: "r1", thinking: "ab", is_thinking: true });
+    expect(update?.patch.thinking).toBe("ab");
+  });
+
+  it("finish is idempotent so double-settled errors cannot end the session early", () => {
+    const session = new StreamSession();
+    session.start(2);
+    session.register({ requestId: "r1", messageId: "m1", conversationId: "c1" });
+    session.register({ requestId: "r2", messageId: "m2", conversationId: "c1" });
+    session.finish("r1");
+    session.finish("r1"); // duplicate settle
+    expect(session.isComplete()).toBe(false);
+    session.finish("r2");
+    expect(session.isComplete()).toBe(true);
+  });
+});
+
+describe("StreamAccumulator partial reset", () => {
+  it("keeps sibling streams' pending updates when one stream finishes", () => {
+    const acc = new StreamAccumulator();
+    const flushed: Record<string, string>[] = [];
+    acc.onFlush((updates) => flushed.push(updates));
+
+    // Simulate a sibling with a queued update, without letting rAF fire yet
+    vi.stubGlobal("requestAnimationFrame", () => 1);
+    acc.queueTokenBatch("m2", "sibling content");
+    acc.reset(["r1"]); // one stream finished
+
+    acc.flush();
+    expect(flushed).toEqual([{ m2: "sibling content" }]);
+  });
+});

--- a/tests/chatStreamFixes.test.ts
+++ b/tests/chatStreamFixes.test.ts
@@ -1,15 +1,26 @@
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { sanitizeOutput } from "@/lib/chat/sanitize";
 import { StreamSession } from "@/lib/chat/stream-session";
 import { StreamAccumulator } from "@/lib/chat/stream-accumulator";
 
+// No vi.* helpers here — CI runs this under `bun test`, whose vitest shim
+// lacks stubGlobal/useFakeTimers. Plain assignment works in both runners.
+const g = globalThis as Record<string, unknown>;
+const realNow = Date.now;
+
 beforeAll(() => {
   // Node env has no rAF; accumulator schedules flushes with it
-  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
     cb(0);
     return 0;
-  });
-  vi.stubGlobal("cancelAnimationFrame", () => {});
+  };
+  g.cancelAnimationFrame = () => {};
+});
+
+afterAll(() => {
+  Date.now = realNow;
+  delete g.requestAnimationFrame;
+  delete g.cancelAnimationFrame;
 });
 
 describe("sanitizeOutput", () => {
@@ -39,14 +50,15 @@ describe("StreamSession", () => {
   }
 
   it("thinking duration excludes answer generation time", () => {
-    vi.useFakeTimers();
+    let now = 1_000_000;
+    Date.now = () => now;
     const session = makeSession();
     session.applyThinking({ request_id: "r1", thinking: "hmm", is_thinking: true });
-    vi.advanceTimersByTime(3000);
-    session.applyThinking({ request_id: "r1", thinking: " done", is_thinking: false });
-    vi.advanceTimersByTime(60000); // long answer afterwards
+    now += 3000;
+    session.applyThinking({ request_id: "r1", thinking: "hmm done", is_thinking: false });
+    now += 60000; // long answer afterwards
     expect(session.thinkingDuration("r1")).toBe(3);
-    vi.useRealTimers();
+    Date.now = realNow;
   });
 
   it("thinking events carry full text — latest payload wins, no duplication", () => {
@@ -76,9 +88,13 @@ describe("StreamAccumulator partial reset", () => {
     acc.onFlush((updates) => flushed.push(updates));
 
     // Simulate a sibling with a queued update, without letting rAF fire yet
-    vi.stubGlobal("requestAnimationFrame", () => 1);
+    g.requestAnimationFrame = () => 1;
     acc.queueTokenBatch("m2", "sibling content");
     acc.reset(["r1"]); // one stream finished
+    g.requestAnimationFrame = (cb: (t: number) => void) => {
+      cb(0);
+      return 0;
+    };
 
     acc.flush();
     expect(flushed).toEqual([{ m2: "sibling content" }]);


### PR DESCRIPTION
## What

Fixes 8 bugs found in a chat streaming/functionality audit, worst first:

1. **Short answers destroyed** — `sanitizeOutput` replaced any final answer under 10 chars ("4", "Yes.") with the fallback error text. Now falls back only when sanitization guts a non-empty response. Also tightened the leak regex to require the template pipe (`<|user|>`) so legit `<user>` markup in code examples survives.
2. **Cross-conversation queue starvation** — messages queued while another conversation streamed were never processed. Queue processing now falls back to any queued message; stop clears the whole queue.
3. **Empty history for background sends** — queued sends for a non-active conversation built history from active-view state (empty). Now loaded from the repository.
4. **Backend infinite retry** — provider stream ending without a `done` marker (connection drop) made the tool loop re-issue the same request forever. Now finalizes with an error.
5. **`thinkingDuration` counted answer time** — duration now stops when thinking stops, not when the stream ends.
6. **Double-settle ended multi-model sessions early** — `StreamSession.finish()` is now idempotent (error paths settle the same request twice: done-chunk with error + rejected invoke).
7. **Aborted messages persisted `isStreaming: true`** — kept streaming UI state after stop.
8. **Stale memory disclosures** — pending memory updates cleared at turn end so regenerate can't re-attach them. Multi-model flush accumulator also no longer drops sibling streams' pending update when one model finishes.

Polish: removed a redundant second rAF buffer in `useMessageStreaming` (one frame less latency per token flush).

## Reviewer notes

- Thinking events intentionally keep the full-payload protocol (backend sends accumulated text each event). A delta protocol was tried during this work and reverted: it corrupts the disclosure on any missed event or frontend/backend version skew (Vite HMR reloads before the Rust rebuild lands).
- `clearQueue` signature changed (no longer per-conversation); the only caller is `stopStreaming`.
- New `tests/chatStreamFixes.test.ts` covers the sanitize edge cases, thinking duration, finish idempotency, and the accumulator partial reset.
- Verified: 111 vitest tests pass, `cargo check` + `cargo test` clean, full `bun run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)