### PR TITLE
fix: disable pinch-to-zoom on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/polyui-icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Tauri + React + Typescript</title>
     <script>
       try {

--- a/src/App.css
+++ b/src/App.css
@@ -239,12 +239,17 @@ html.reduce-motion {
     --dur-slow: 0.01ms;
 }
 
+html {
+    touch-action: manipulation;
+}
+
 body {
     background: var(--background);
     color: var(--foreground);
     font-family: "Geist Variable", "Inter", system-ui, sans-serif;
     user-select: none;
     -webkit-user-select: none;
+    touch-action: manipulation;
 }
 
 #root {


### PR DESCRIPTION
Add maximum-scale/user-scalable=no to viewport meta and touch-action: manipulation to html/body CSS.