### PR TITLE
feat(viewport): suspend iframe when drawer closed, add keepViewportActive setting

### DIFF
--- a/src/features/agent/AgentViewportDrawer.tsx
+++ b/src/features/agent/AgentViewportDrawer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { usePauseableHandler } from "@/lib/idle/hooks";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -72,10 +73,15 @@ export function AgentViewportDrawer() {
   const setDrawerWidth = useViewportStore((state) => state.actions.setDrawerWidth);
   const reduceMotion = useSettingsStore((state) => state.performance.reduceMotion);
   const reduceTransparency = useSettingsStore((state) => state.performance.reduceTransparency);
+  const keepViewportActive = useSettingsStore((state) => state.performance.keepViewportActive);
   const [dragging, setDragging] = useState(false);
   const [url, setUrl] = useState("");
   const [frameNonce, setFrameNonce] = useState(0);
   const [frameLoading, setFrameLoading] = useState(false);
+  const [frameSuspended, setFrameSuspended] = useState(false);
+  const [frameOffloaded, setFrameOffloaded] = useState(false);
+  const offloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const OFFLOAD_TIMEOUT_MS = 120_000;
   const [draggingTab, setDraggingTab] = useState<ViewportTab | null>(null);
   const [history, setHistory] = useState<BrowserHistoryState>({ entries: [], index: -1 });
   const historyMoveRef = useRef(false);
@@ -135,6 +141,55 @@ export function AgentViewportDrawer() {
   const reviewActive = activeTab === "review";
   const browserLoading = Boolean(session?.url && frameLoading);
   const showHttpsWarning = Boolean(session?.url && isHttpsUrl(session.url));
+
+  useEffect(() => {
+    if (keepViewportActive) return;
+    if (!visible && (session?.url || browserOpen)) {
+      setFrameSuspended(true);
+      setFrameOffloaded(false);
+      offloadTimerRef.current = setTimeout(() => {
+        setFrameOffloaded(true);
+      }, OFFLOAD_TIMEOUT_MS);
+    } else if (visible && (frameSuspended || frameOffloaded)) {
+      if (offloadTimerRef.current) {
+        clearTimeout(offloadTimerRef.current);
+        offloadTimerRef.current = null;
+      }
+      setFrameSuspended(false);
+      setFrameOffloaded(false);
+      if (session?.url) {
+        setFrameLoading(true);
+        setFrameNonce((n) => n + 1);
+      }
+    }
+    return () => {
+      if (offloadTimerRef.current) {
+        clearTimeout(offloadTimerRef.current);
+        offloadTimerRef.current = null;
+      }
+    };
+  }, [visible, keepViewportActive]);
+
+  usePauseableHandler("viewport-drawer", {
+    onPause: () => {
+      if (keepViewportActive) return;
+      if (!visible && !frameSuspended && (session?.url || browserOpen)) {
+        setFrameSuspended(true);
+      }
+    },
+    onResume: () => {
+      if (keepViewportActive) return;
+      if (visible && (frameSuspended || frameOffloaded)) {
+        setFrameSuspended(false);
+        setFrameOffloaded(false);
+        if (session?.url) {
+          setFrameLoading(true);
+          setFrameNonce((n) => n + 1);
+        }
+      }
+    },
+    priority: 100,
+  });
 
   const openTypedUrl = () => {
     const href = resolveBrowserInput(url);
@@ -456,17 +511,21 @@ export function AgentViewportDrawer() {
           <div className="relative min-h-0 flex-1 bg-[#101010]">
             {session?.url ? (
               <>
-                <iframe
-                  key={`${session.url}#${frameNonce}`}
-                  src={session.url}
-                  title="Viewport preview"
-                  className="h-full w-full border-0 bg-white"
-                  sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads"
-                  referrerPolicy="no-referrer"
-                  allow="clipboard-read; clipboard-write; fullscreen"
-                  onLoad={() => setFrameLoading(false)}
-                />
-                {browserLoading ? (
+                {frameOffloaded ? (
+                  <BrowserNewTabEmpty />
+                ) : (
+                  <iframe
+                    key={frameSuspended ? "__suspended__" : `${session.url}#${frameNonce}`}
+                    src={frameSuspended ? "about:blank" : session.url}
+                    title="Viewport preview"
+                    className="h-full w-full border-0 bg-white"
+                    sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads"
+                    referrerPolicy="no-referrer"
+                    allow="clipboard-read; clipboard-write; fullscreen"
+                    onLoad={() => setFrameLoading(false)}
+                  />
+                )}
+                {browserLoading && !frameSuspended ? (
                   <div
                     className={cn(
                       "pointer-events-none absolute inset-0 flex items-center justify-center",

--- a/src/features/agent/viewportStore.ts
+++ b/src/features/agent/viewportStore.ts
@@ -43,6 +43,7 @@ type ViewportStore = {
   tabOrder: ViewportTab[];
   drawerOpen: boolean;
   drawerWidth: number;
+  lastActiveTab: ViewportTab;
   actions: {
     opened: (session: Omit<ViewportSession, "status" | "openedAt">) => void;
     browserOpened: () => void;
@@ -59,6 +60,7 @@ type ViewportStore = {
 };
 
 const WIDTH_STORAGE_KEY = "poly_agent_viewport_width";
+const LAST_TAB_KEY = "poly_agent_viewport_last_tab";
 export const VIEWPORT_MIN_WIDTH = 320;
 export const VIEWPORT_MAX_WIDTH = 900;
 
@@ -84,6 +86,12 @@ function loadWidth(): number {
   return Number.isFinite(raw) && raw >= VIEWPORT_MIN_WIDTH && raw <= VIEWPORT_MAX_WIDTH ? raw : 440;
 }
 
+function loadLastTab(): ViewportTab {
+  const raw = typeof localStorage === "undefined" ? null : localStorage.getItem(LAST_TAB_KEY);
+  if (raw === "browser" || raw === "review") return raw;
+  return "browser";
+}
+
 export const useViewportStore = create<ViewportStore>((set) => ({
   session: null,
   review: null,
@@ -92,6 +100,7 @@ export const useViewportStore = create<ViewportStore>((set) => ({
   tabOrder: [],
   drawerOpen: false,
   drawerWidth: loadWidth(),
+  lastActiveTab: loadLastTab(),
   actions: {
     opened: (session) =>
       set((state) => ({
@@ -156,7 +165,14 @@ export const useViewportStore = create<ViewportStore>((set) => ({
       }),
     setActiveTab: (activeTab) => set({ activeTab, drawerOpen: true }),
     moveTab: (tab, target, side) => set((state) => ({ tabOrder: moveTab(state.tabOrder, tab, target, side) })),
-    setDrawerOpen: (drawerOpen) => set({ drawerOpen }),
+    setDrawerOpen: (drawerOpen) =>
+      set((state) => {
+        if (!drawerOpen) {
+          localStorage.setItem(LAST_TAB_KEY, state.activeTab);
+          return { drawerOpen, lastActiveTab: state.activeTab };
+        }
+        return { drawerOpen };
+      }),
     setDrawerWidth: (drawerWidth) => {
       localStorage.setItem(WIDTH_STORAGE_KEY, String(drawerWidth));
       set({ drawerWidth });
@@ -294,6 +310,9 @@ export function showViewportDrawer(): void {
   const state = useViewportStore.getState();
   if (state.browserOpen || state.session || state.review) {
     useViewportStore.getState().actions.setDrawerOpen(true);
+    if (state.activeTab !== state.lastActiveTab) {
+      useViewportStore.getState().actions.setActiveTab(state.lastActiveTab);
+    }
   }
 }
 

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -35,6 +35,7 @@ export type PerformanceSettings = {
   reduceMotion: boolean;
   reduceTransparency: boolean;
   appZoom: number;
+  keepViewportActive: boolean;
 };
 
 type SettingsState = {
@@ -60,7 +61,7 @@ const defaultTts: TtsSettings = {
   },
 };
 
-const SETTINGS_VERSION = 15;
+const SETTINGS_VERSION = 16;
 
 export const defaultDictation: DictationSettings = {
   enabled: true,
@@ -72,6 +73,7 @@ export const defaultPerformance: PerformanceSettings = {
   reduceMotion: false,
   reduceTransparency: false,
   appZoom: 1,
+  keepViewportActive: false,
 };
 
 function createDefaultWebSearchSettings(): WebSearchSettings {
@@ -188,6 +190,9 @@ export const useSettingsStore = create<SettingsState>()(
               ...(state.general.webSearch?.apiKeys ?? {}),
             },
           };
+        }
+        if (version < 16) {
+          state.performance = { ...defaultPerformance, ...state.performance, keepViewportActive: false };
         }
         startupPhase("settings migration complete");
         return state as SettingsState;

--- a/tests/viewportStore.test.ts
+++ b/tests/viewportStore.test.ts
@@ -17,6 +17,7 @@ const resetViewportStore = () => {
     tabOrder: [],
     drawerOpen: false,
     drawerWidth: 440,
+    lastActiveTab: "browser",
   });
 };
 


### PR DESCRIPTION
Fixes lag when closing viewport drawer with a webpage open.

- Iframe suspends (navigates to about:blank) immediately on drawer close
- Fully offloads iframe from DOM after 2 minutes of inactivity
- Registers idle handler to suspend/resume with app idle state
- Saves last active tab to localStorage for restore on reopen
- Adds `performance.keepViewportActive` setting (default off) to opt out of suspension