### PR TITLE
Sync dev into main: supertonic TTS, engine selector, mobile pairing guards

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "marked": "^18.0.4",
         "motion": "^12.42.0",
         "motion-primitives": "^0.1.0",
+        "qrcode.react": "^4.2.0",
         "radix-ui": "^1.6.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1180,6 +1181,8 @@
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 

--- a/mobile.html
+++ b/mobile.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/polyui-icon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>PolyUI Mobile</title>
+    <script>
+      document.documentElement.classList.add("dark");
+      document.documentElement.style.backgroundColor = "#171717";
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/mobile.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "motion": "^12.42.0",
     "motion-primitives": "^0.1.0",
     "radix-ui": "^1.6.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -87,6 +87,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +926,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,7 +1072,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1056,6 +1094,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1093,11 +1142,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1108,7 +1178,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2012,6 +2082,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +2655,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +2733,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
+
+[[package]]
 name = "mac-notification-sys"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +2768,16 @@ dependencies = [
  "log",
  "tendril",
  "web_atoms",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
 ]
 
 [[package]]
@@ -2772,6 +2874,22 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+ "rayon",
 ]
 
 [[package]]
@@ -2883,6 +3001,15 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3282,6 +3409,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "libloading 0.9.0",
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
+
+[[package]]
 name = "os_info"
 version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,6 +3514,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -3448,7 +3609,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
+ "der 0.7.10",
  "pkcs8",
  "spki",
 ]
@@ -3459,7 +3620,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "spki",
 ]
 
@@ -3537,7 +3698,7 @@ dependencies = [
  "bcrypt",
  "chrono",
  "cpal",
- "dirs",
+ "dirs 6.0.0",
  "futures",
  "gtk",
  "hound",
@@ -3560,6 +3721,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-sql",
+ "tauri-plugin-supertonic",
  "tauri-plugin-window-state",
  "tokio",
  "tokio-stream",
@@ -3568,6 +3730,21 @@ dependencies = [
  "whisper-rs",
  "windows-sys 0.59.0",
  "wry",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -3868,10 +4045,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3889,6 +4102,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4181,6 +4405,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4637,6 +4862,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "softbuffer"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,7 +4936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -4900,6 +5136,33 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "st-tts"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dirs 5.0.1",
+ "hex",
+ "hound",
+ "ndarray",
+ "ort",
+ "rand 0.8.6",
+ "rand_distr",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "unicode-normalization",
+ "ureq",
+ "zip",
 ]
 
 [[package]]
@@ -5129,7 +5392,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -5179,7 +5442,7 @@ checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -5393,6 +5656,23 @@ dependencies = [
  "time",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "tauri-plugin-supertonic"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "dirs 5.0.1",
+ "ndarray",
+ "serde",
+ "serde_json",
+ "st-tts",
+ "tauri",
+ "tauri-plugin",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -5922,7 +6202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -6053,6 +6333,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "der 0.8.0",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6082,6 +6394,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6378,6 +6696,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7141,7 +7468,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",
@@ -7370,10 +7697,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,7 +45,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-os = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2"
-tauri-plugin-supertonic = { path = "../../../supertonic-rs/tauri-plugin" }
+tauri-plugin-supertonic = "0.2"
 windows-sys = { version = "0.59", features = ["Win32_Graphics_Dwm", "Win32_Foundation"] }
 raw-window-handle = "0.6"
 dirs = "6"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-os = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-supertonic = { path = "../../../supertonic-rs/tauri-plugin" }
 windows-sys = { version = "0.59", features = ["Win32_Graphics_Dwm", "Win32_Foundation"] }
 raw-window-handle = "0.6"
 dirs = "6"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -32,6 +32,7 @@
     "window-state:default",
     "notification:default",
     "dialog:default",
+    "supertonic:default",
     "opener:default",
     "fs:allow-write-text-file",
     "fs:allow-read-file",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,6 +84,8 @@ pub fn run() {
     let builder = builder.plugin(tauri_plugin_notification::init());
     startup_log::log_phase("plugin init: dialog");
     let builder = builder.plugin(tauri_plugin_dialog::init());
+    startup_log::log_phase("plugin init: supertonic");
+    let builder = builder.plugin(tauri_plugin_supertonic::init());
 
     startup_log::log_phase("plugins registered");
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod commands;
 mod db;
 mod error;
 mod memory;
+mod mobile_pairing;
 mod models;
 mod providers;
 mod startup_log;
@@ -32,6 +33,9 @@ use crate::commands::system_commands::{
     agent_list_directory, agent_list_workspaces, agent_prepare_chat_sandbox, agent_read_text_file,
     agent_read_web_results, agent_run_command, agent_search_web, agent_web_search,
     agent_write_text_file,
+};
+use crate::mobile_pairing::{
+    mobile_pairing_start, mobile_pairing_status, mobile_pairing_stop, MobilePairingState,
 };
 use crate::updater::{check_for_updates, download_update, install_update};
 use crate::whisper_state::WhisperState;
@@ -85,6 +89,7 @@ pub fn run() {
 
     let result = builder
         .manage(agent_viewport::ViewportState::default())
+        .manage(MobilePairingState::default())
         .setup(|app| {
             startup_log::log_phase("setup hook entered");
             match app.path().app_data_dir() {
@@ -233,6 +238,9 @@ pub fn run() {
             log_startup_error,
             log_startup_phase,
             startup_log_path,
+            mobile_pairing_start,
+            mobile_pairing_stop,
+            mobile_pairing_status,
         ])
         .run(context);
 

--- a/src-tauri/src/mobile_pairing.rs
+++ b/src-tauri/src/mobile_pairing.rs
@@ -1,7 +1,17 @@
+use crate::models::chat::ChatMessage;
+use crate::providers::base::ProviderType;
+use crate::providers::factory::ProviderFactory;
+use crate::providers::selector::ProviderSelector;
+use crate::AppState;
+use futures::StreamExt;
+use serde::Deserialize;
 use serde::Serialize;
+use sqlx::Row;
+use std::fs;
 use std::net::{IpAddr, Ipv4Addr, UdpSocket};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tauri::State;
+use tauri::{Emitter, State};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{oneshot, Mutex};
@@ -37,6 +47,8 @@ impl Default for MobilePairingState {
 #[tauri::command]
 pub async fn mobile_pairing_start(
     state: State<'_, MobilePairingState>,
+    app_state: State<'_, AppState>,
+    app_handle: tauri::AppHandle,
 ) -> Result<MobilePairingInfo, String> {
     let mut current = state.current.lock().await;
     if let Some(session) = current.as_ref() {
@@ -55,7 +67,13 @@ pub async fn mobile_pairing_start(
     let info = build_pairing_info(&host, port, &token);
     let (stop_tx, stop_rx) = oneshot::channel();
 
-    tokio::spawn(run_pairing_server(listener, token, stop_rx));
+    tokio::spawn(run_pairing_server(
+        listener,
+        token,
+        app_state.db.clone(),
+        app_handle,
+        stop_rx,
+    ));
     *current = Some(MobilePairingSession {
         info: info.clone(),
         stop: stop_tx,
@@ -82,11 +100,7 @@ pub async fn mobile_pairing_status(
 
 fn build_pairing_info(host: &str, port: u16, token: &str) -> MobilePairingInfo {
     let http_base_url = format!("http://{host}:{port}");
-    let encoded_base = percent_encoding::utf8_percent_encode(
-        &http_base_url,
-        percent_encoding::NON_ALPHANUMERIC,
-    );
-    let url = format!("polyui://pair?base={encoded_base}&token={token}");
+    let url = format!("{http_base_url}/mobile.html?token={token}");
     MobilePairingInfo {
         url,
         http_base_url,
@@ -108,6 +122,8 @@ fn lan_ip() -> Option<Ipv4Addr> {
 async fn run_pairing_server(
     listener: TcpListener,
     token: String,
+    db: sqlx::SqlitePool,
+    app_handle: tauri::AppHandle,
     mut stop: oneshot::Receiver<()>,
 ) {
     let token = Arc::new(token);
@@ -117,50 +133,654 @@ async fn run_pairing_server(
             accepted = listener.accept() => {
                 let Ok((stream, _addr)) = accepted else { continue };
                 let token = Arc::clone(&token);
+                let db = db.clone();
+                let app_handle = app_handle.clone();
                 tokio::spawn(async move {
-                    let _ = handle_connection(stream, token.as_str()).await;
+                    let _ = handle_connection(stream, token.as_str(), db, app_handle).await;
                 });
             }
         }
     }
 }
 
-async fn handle_connection(mut stream: TcpStream, token: &str) -> std::io::Result<()> {
-    let mut buffer = [0_u8; 2048];
-    let read = stream.read(&mut buffer).await?;
-    let request = String::from_utf8_lossy(&buffer[..read]);
-    let path = request
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .unwrap_or("/");
-    let response = response_for_path(path, token);
-    stream.write_all(response.as_bytes()).await
+#[derive(Deserialize)]
+struct BrowserChatRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    conversation_id: Option<String>,
+    is_temporary: Option<bool>,
+    provider_type: Option<ProviderType>,
+    provider_config_id: Option<i64>,
 }
 
+#[derive(Deserialize)]
+struct BrowserConversationRequest {
+    id: String,
+    title: String,
+    is_temporary: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct BrowserMessageRequest {
+    id: String,
+    conversation_id: String,
+    role: String,
+    content: String,
+    model: Option<String>,
+    provider: Option<ProviderType>,
+    is_temporary: Option<bool>,
+}
+
+async fn handle_connection(
+    mut stream: TcpStream,
+    token: &str,
+    db: sqlx::SqlitePool,
+    app_handle: tauri::AppHandle,
+) -> std::io::Result<()> {
+    let mut buffer = [0_u8; 65_536];
+    let read = stream.read(&mut buffer).await?;
+    let request = String::from_utf8_lossy(&buffer[..read]);
+    let first_line = request
+        .lines()
+        .next()
+        .unwrap_or("GET / HTTP/1.1");
+    let mut parts = first_line.split_whitespace();
+    let method = parts.next().unwrap_or("GET");
+    let path = parts.next().unwrap_or("/");
+    let body = request.split("\r\n\r\n").nth(1).unwrap_or("");
+    if method == "POST" && path.starts_with("/api/chat-stream") {
+        return handle_chat_stream_response(stream, path, body, token, db, app_handle).await;
+    }
+    let response = response_for_request(method, path, body, token, db, app_handle).await;
+    stream.write_all(&response).await
+}
+
+async fn handle_chat_stream_response(
+    mut stream: TcpStream,
+    path: &str,
+    body: &str,
+    token: &str,
+    db: sqlx::SqlitePool,
+    app_handle: tauri::AppHandle,
+) -> std::io::Result<()> {
+    if !token_matches(path, token) {
+        stream.write_all(&unauthorized_response()).await?;
+        return Ok(());
+    }
+    stream
+        .write_all(
+            b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncache-control: no-cache\r\nconnection: close\r\n\r\n",
+        )
+        .await?;
+
+    let request = match serde_json::from_str::<BrowserChatRequest>(body) {
+        Ok(request) => request,
+        Err(error) => {
+            write_sse(&mut stream, "error", &serde_json::json!({ "error": error.to_string() }).to_string()).await?;
+            return Ok(());
+        }
+    };
+    let provider_type = request.provider_type.unwrap_or(ProviderType::OllamaLocal);
+    let provider_result = match request.provider_config_id {
+        Some(id) => get_provider_config_by_id(&db, id, provider_type)
+            .await
+            .and_then(|config| {
+                ProviderFactory::create_chat_provider(config)
+                    .ok_or_else(|| "Provider configuration is unavailable.".to_string())
+            }),
+        None => ProviderSelector::new(db.clone()).get_provider(provider_type, None).await,
+    };
+    let provider = match provider_result {
+        Ok(provider) => provider,
+        Err(error) => {
+            write_sse(&mut stream, "error", &serde_json::json!({ "error": error }).to_string()).await?;
+            return Ok(());
+        }
+    };
+    let mut provider_stream = match provider
+        .chat_completion(request.model.clone(), request.messages, None, None, None)
+        .await
+    {
+        Ok(stream) => stream,
+        Err(error) => {
+            write_sse(&mut stream, "error", &serde_json::json!({ "error": error }).to_string()).await?;
+            return Ok(());
+        }
+    };
+
+    let mut content = String::new();
+    while let Some(chunk) = provider_stream.next().await {
+        match chunk {
+            Ok(payload) => {
+                if !payload.content.is_empty() {
+                    content.push_str(&payload.content);
+                    write_sse(
+                        &mut stream,
+                        "chunk",
+                        &serde_json::json!({ "content": payload.content }).to_string(),
+                    )
+                    .await?;
+                }
+            }
+            Err(error) => {
+                write_sse(&mut stream, "error", &serde_json::json!({ "error": error }).to_string()).await?;
+                return Ok(());
+            }
+        }
+    }
+
+    let assistant_id = Uuid::new_v4().to_string();
+    if !request.is_temporary.unwrap_or(false) {
+        if let Some(conversation_id) = request.conversation_id.as_deref() {
+            let message = BrowserMessageRequest {
+                id: assistant_id.clone(),
+                conversation_id: conversation_id.to_string(),
+                role: "assistant".to_string(),
+                content: content.clone(),
+                model: Some(request.model),
+                provider: Some(provider_type),
+                is_temporary: Some(false),
+            };
+            let _ = insert_message(&db, &message).await;
+            emit_mobile_chat_updated(&app_handle, Some(conversation_id));
+        }
+    }
+    write_sse(
+        &mut stream,
+        "done",
+        &serde_json::json!({ "id": assistant_id, "content": content, "provider": provider_type }).to_string(),
+    )
+    .await
+}
+
+async fn write_sse(stream: &mut TcpStream, event: &str, data: &str) -> std::io::Result<()> {
+    stream
+        .write_all(format!("event: {event}\ndata: {data}\n\n").as_bytes())
+        .await
+}
+
+async fn response_for_request(
+    method: &str,
+    path: &str,
+    body: &str,
+    token: &str,
+    db: sqlx::SqlitePool,
+    app_handle: tauri::AppHandle,
+) -> Vec<u8> {
+    if let Some(response) = response_for_static_path(method, path, token) {
+        return response;
+    }
+    if !token_matches(path, token) {
+        return unauthorized_response();
+    }
+
+    if method == "GET" && path.starts_with("/api/status") {
+        return json_response(200, r#"{"ok":true,"app":"PolyUI"}"#);
+    }
+
+    if method == "GET" && path.starts_with("/api/models") {
+        let configs = get_all_enabled_provider_configs(&db).await;
+        let body = match configs {
+            Ok(configs) => {
+                let mut choices = Vec::new();
+                for config in configs.into_iter().filter(|config| config.enabled) {
+                    let provider_models = match ProviderFactory::create_model_catalog(config.clone()) {
+                        Some(catalog) => catalog
+                            .get_available_models()
+                            .await
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(|model| model.name)
+                            .collect::<Vec<_>>(),
+                        None => Vec::new(),
+                    };
+                    let models = if provider_models.is_empty() {
+                        config
+                            .model_suggestions
+                            .as_deref()
+                            .and_then(|raw| serde_json::from_str::<Vec<String>>(raw).ok())
+                            .unwrap_or_default()
+                    } else {
+                        provider_models
+                    };
+                    for model in models {
+                        choices.push(serde_json::json!({
+                            "name": model,
+                            "providerType": config.provider_type,
+                            "providerConfigId": config.id,
+                        }));
+                    }
+                }
+                serde_json::json!({ "ok": true, "models": choices }).to_string()
+            }
+            Err(error) => serde_json::json!({ "ok": false, "error": error }).to_string(),
+        };
+        return json_response(200, &body);
+    }
+
+    if method == "GET" && path.starts_with("/api/conversations") {
+        let body = match list_conversations(&db).await {
+            Ok(conversations) => serde_json::json!({ "ok": true, "conversations": conversations }).to_string(),
+            Err(error) => serde_json::json!({ "ok": false, "error": error }).to_string(),
+        };
+        return json_response(200, &body);
+    }
+
+    if method == "POST" && path.starts_with("/api/conversations") {
+        let request = match serde_json::from_str::<BrowserConversationRequest>(body) {
+            Ok(request) => request,
+            Err(error) => return json_response(400, &serde_json::json!({ "ok": false, "error": error.to_string() }).to_string()),
+        };
+        if request.is_temporary.unwrap_or(false) {
+            return json_response(200, r#"{"ok":true}"#);
+        }
+        let owner_id = mobile_owner_account_id(&db).await.unwrap_or_default();
+        let result = sqlx::query("INSERT INTO conversations (id, title, createdAt, updatedAt, isArchived, userId, folderId) VALUES (?1, ?2, datetime('now'), datetime('now'), 0, ?3, NULL)")
+            .bind(request.id)
+            .bind(request.title)
+            .bind(owner_id)
+            .execute(&db)
+            .await;
+        let body = match result {
+            Ok(_) => {
+                emit_mobile_chat_updated(&app_handle, None);
+                r#"{"ok":true}"#.to_string()
+            },
+            Err(error) => serde_json::json!({ "ok": false, "error": error.to_string() }).to_string(),
+        };
+        return json_response(200, &body);
+    }
+
+    if method == "GET" && path.starts_with("/api/messages") {
+        let conversation_id = query_value(path, "conversationId").unwrap_or_default();
+        let body = match list_messages(&db, &conversation_id).await {
+            Ok(messages) => serde_json::json!({ "ok": true, "messages": messages }).to_string(),
+            Err(error) => serde_json::json!({ "ok": false, "error": error }).to_string(),
+        };
+        return json_response(200, &body);
+    }
+
+    if method == "POST" && path.starts_with("/api/messages") {
+        let request = match serde_json::from_str::<BrowserMessageRequest>(body) {
+            Ok(request) => request,
+            Err(error) => return json_response(400, &serde_json::json!({ "ok": false, "error": error.to_string() }).to_string()),
+        };
+        if request.is_temporary.unwrap_or(false) {
+            return json_response(200, r#"{"ok":true}"#);
+        }
+        let result = insert_message(&db, &request).await;
+        let body = match result {
+            Ok(_) => {
+                emit_mobile_chat_updated(&app_handle, Some(&request.conversation_id));
+                r#"{"ok":true}"#.to_string()
+            },
+            Err(error) => serde_json::json!({ "ok": false, "error": error }).to_string(),
+        };
+        return json_response(200, &body);
+    }
+
+    if method == "POST" && path.starts_with("/api/chat") {
+        let request = match serde_json::from_str::<BrowserChatRequest>(body) {
+            Ok(request) => request,
+            Err(error) => {
+                return json_response(
+                    400,
+                    &serde_json::json!({ "ok": false, "error": error.to_string() }).to_string(),
+                )
+            }
+        };
+        let provider_type = request.provider_type.unwrap_or(ProviderType::OllamaLocal);
+        let provider_result = match request.provider_config_id {
+            Some(id) => get_provider_config_by_id(&db, id, provider_type)
+                .await
+                .and_then(|config| {
+                    ProviderFactory::create_chat_provider(config)
+                        .ok_or_else(|| "Provider configuration is unavailable.".to_string())
+                }),
+            None => ProviderSelector::new(db.clone()).get_provider(provider_type, None).await,
+        };
+        let body = match provider_result {
+            Ok(provider) => match provider
+                .chat_completion(request.model, request.messages, None, None, None)
+                .await
+            {
+                Ok(mut stream) => {
+                    let mut content = String::new();
+                    let mut error = None;
+                    while let Some(chunk) = stream.next().await {
+                        match chunk {
+                            Ok(payload) => content.push_str(&payload.content),
+                            Err(message) => {
+                                error = Some(message);
+                                break;
+                            }
+                        }
+                    }
+                    match error {
+                        Some(error) => serde_json::json!({ "ok": false, "error": error }).to_string(),
+                        None => {
+                            if !request.is_temporary.unwrap_or(false) {
+                                if let Some(conversation_id) = request.conversation_id.as_deref() {
+                                    let message = BrowserMessageRequest {
+                                        id: Uuid::new_v4().to_string(),
+                                        conversation_id: conversation_id.to_string(),
+                                        role: "assistant".to_string(),
+                                        content: content.clone(),
+                                        model: None,
+                                        provider: Some(provider_type),
+                                        is_temporary: Some(false),
+                                    };
+                                    let _ = insert_message(&db, &message).await;
+                                    emit_mobile_chat_updated(&app_handle, Some(conversation_id));
+                                }
+                            }
+                            serde_json::json!({ "ok": true, "message": { "role": "assistant", "content": content, "provider": provider_type } }).to_string()
+                        },
+                    }
+                }
+                Err(error) => serde_json::json!({ "ok": false, "error": error }).to_string(),
+            },
+            Err(error) => serde_json::json!({ "ok": false, "error": error }).to_string(),
+        };
+        return json_response(200, &body);
+    }
+
+    not_found_response()
+}
+
+#[cfg(test)]
 fn response_for_path(path: &str, token: &str) -> String {
+    String::from_utf8_lossy(
+        &response_for_static_path("GET", path, token).unwrap_or_else(|| unauthorized_response()),
+    )
+    .into_owned()
+}
+
+fn response_for_static_path(method: &str, path: &str, token: &str) -> Option<Vec<u8>> {
+    if method != "GET" {
+        return None;
+    }
     if path == "/health" {
-        return http_response(200, r#"{"ok":true,"app":"PolyUI"}"#);
+        return Some(json_response(200, r#"{"ok":true,"app":"PolyUI"}"#));
+    }
+
+    if path == "/polyui-icon.png" {
+        return Some(serve_public_file("polyui-icon.png"));
     }
 
     let expected = format!("/pair/verify?token={token}");
     if path == expected {
-        return http_response(200, r#"{"ok":true,"app":"PolyUI"}"#);
+        return Some(json_response(200, r#"{"ok":true,"app":"PolyUI"}"#));
     }
 
-    http_response(401, r#"{"ok":false}"#)
+    if path.starts_with("/mobile.html?") && token_matches(path, token) {
+        return Some(serve_dist_file("mobile.html"));
+    }
+
+    if path.starts_with("/assets/") {
+        return Some(serve_dist_file(path.trim_start_matches('/')));
+    }
+
+    None
 }
 
-fn http_response(status: u16, body: &str) -> String {
+fn token_matches(path: &str, token: &str) -> bool {
+    path.split_once('?')
+        .map(|(_, query)| {
+            url::form_urlencoded::parse(query.as_bytes())
+                .any(|(key, value)| key == "token" && value == token)
+        })
+        .unwrap_or(false)
+}
+
+fn query_value(path: &str, name: &str) -> Option<String> {
+    path.split_once('?').and_then(|(_, query)| {
+        url::form_urlencoded::parse(query.as_bytes())
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.into_owned())
+    })
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MobileChatUpdatedPayload {
+    conversation_id: Option<String>,
+}
+
+fn emit_mobile_chat_updated(app_handle: &tauri::AppHandle, conversation_id: Option<&str>) {
+    let _ = app_handle.emit(
+        "mobile-chat-updated",
+        MobileChatUpdatedPayload {
+            conversation_id: conversation_id.map(str::to_string),
+        },
+    );
+}
+
+async fn list_conversations(db: &sqlx::SqlitePool) -> Result<serde_json::Value, String> {
+    let rows = sqlx::query("SELECT id, title, createdAt, updatedAt, isArchived, folderId FROM conversations ORDER BY updatedAt DESC")
+        .fetch_all(db)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(serde_json::Value::Array(rows.into_iter().map(|row| {
+        serde_json::json!({
+            "id": row.get::<String, _>("id"),
+            "title": row.get::<String, _>("title"),
+            "createdAt": row.get::<String, _>("createdAt"),
+            "updatedAt": row.get::<String, _>("updatedAt"),
+            "isArchived": row.get::<i64, _>("isArchived") != 0,
+            "folderId": row.try_get::<String, _>("folderId").ok(),
+        })
+    }).collect()))
+}
+
+async fn mobile_owner_account_id(db: &sqlx::SqlitePool) -> Result<String, String> {
+    if let Ok(row) = sqlx::query("SELECT account_id FROM provider_configs WHERE account_id <> '' ORDER BY updated_at DESC LIMIT 1")
+        .fetch_one(db)
+        .await
+    {
+        return Ok(row.get::<String, _>("account_id"));
+    }
+    if let Ok(row) = sqlx::query("SELECT userId FROM conversations WHERE userId <> '' ORDER BY updatedAt DESC LIMIT 1")
+        .fetch_one(db)
+        .await
+    {
+        return Ok(row.get::<String, _>("userId"));
+    }
+    Ok(String::new())
+}
+
+async fn get_all_enabled_provider_configs(db: &sqlx::SqlitePool) -> Result<Vec<crate::providers::base::ProviderConfig>, String> {
+    sqlx::query_as::<_, crate::providers::base::ProviderConfig>(
+        "SELECT id, account_id, provider_type, enabled, ollama_host, ollama_api_key, ollama_api_base_url, api_key, api_base_url, priority, preset, headers, model_suggestions FROM provider_configs WHERE enabled = 1 ORDER BY account_id ASC, priority ASC"
+    )
+    .fetch_all(db)
+    .await
+    .map_err(|error| error.to_string())
+}
+
+async fn get_provider_config_by_id(
+    db: &sqlx::SqlitePool,
+    id: i64,
+    provider_type: ProviderType,
+) -> Result<crate::providers::base::ProviderConfig, String> {
+    sqlx::query_as::<_, crate::providers::base::ProviderConfig>(
+        "SELECT id, account_id, provider_type, enabled, ollama_host, ollama_api_key, ollama_api_base_url, api_key, api_base_url, priority, preset, headers, model_suggestions FROM provider_configs WHERE id = ?1 AND provider_type = ?2 AND enabled = 1"
+    )
+    .bind(id)
+    .bind(provider_type)
+    .fetch_one(db)
+    .await
+    .map_err(|error| error.to_string())
+}
+
+async fn list_messages(db: &sqlx::SqlitePool, conversation_id: &str) -> Result<serde_json::Value, String> {
+    let rows = sqlx::query("SELECT id, conversationId, role, content, createdAt, model, provider, status, errorMessage FROM messages WHERE conversationId = ?1 ORDER BY createdAt ASC")
+        .bind(conversation_id)
+        .fetch_all(db)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(serde_json::Value::Array(rows.into_iter().map(|row| {
+        serde_json::json!({
+            "id": row.get::<String, _>("id"),
+            "conversationId": row.get::<String, _>("conversationId"),
+            "role": row.get::<String, _>("role"),
+            "content": row.get::<String, _>("content"),
+            "createdAt": row.get::<String, _>("createdAt"),
+            "model": row.try_get::<String, _>("model").ok(),
+            "provider": row.try_get::<ProviderType, _>("provider").ok(),
+            "status": row.try_get::<String, _>("status").ok(),
+            "errorMessage": row.try_get::<String, _>("errorMessage").ok(),
+        })
+    }).collect()))
+}
+
+async fn insert_message(db: &sqlx::SqlitePool, message: &BrowserMessageRequest) -> Result<(), String> {
+    let owner_id = mobile_owner_account_id(db).await.unwrap_or_default();
+    if !owner_id.is_empty() {
+        let _ = sqlx::query("UPDATE conversations SET userId = ?1 WHERE id = ?2 AND (userId IS NULL OR userId = '')")
+            .bind(&owner_id)
+            .bind(&message.conversation_id)
+            .execute(db)
+            .await;
+    }
+    sqlx::query("INSERT INTO messages (id, conversationId, role, content, createdAt, attachments, model, provider, thinking, thinkingDuration, webSearch, agent, status, errorMessage) VALUES (?1, ?2, ?3, ?4, datetime('now'), NULL, ?5, ?6, NULL, NULL, NULL, NULL, 'complete', NULL)")
+        .bind(&message.id)
+        .bind(&message.conversation_id)
+        .bind(&message.role)
+        .bind(&message.content)
+        .bind(&message.model)
+        .bind(message.provider)
+        .execute(db)
+        .await
+        .map_err(|error| error.to_string())?;
+    sqlx::query("UPDATE conversations SET updatedAt = datetime('now') WHERE id = ?1")
+        .bind(&message.conversation_id)
+        .execute(db)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+fn unauthorized_response() -> Vec<u8> {
+    json_response(401, r#"{"ok":false}"#)
+}
+
+fn not_found_response() -> Vec<u8> {
+    json_response(404, r#"{"ok":false,"error":"Not found"}"#)
+}
+
+fn binary_response(content_type: &str, body: &[u8]) -> Vec<u8> {
+    let header = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        body.len()
+    );
+    let mut response = header.into_bytes();
+    response.extend_from_slice(body);
+    response
+}
+
+fn json_response(status: u16, body: &str) -> Vec<u8> {
+    http_response(status, "application/json", body)
+}
+
+fn http_response(status: u16, content_type: &str, body: &str) -> Vec<u8> {
     let reason = match status {
         200 => "OK",
         401 => "Unauthorized",
+        404 => "Not Found",
+        400 => "Bad Request",
         _ => "Error",
     };
     format!(
-        "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        "HTTP/1.1 {status} {reason}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
         body.len()
     )
+    .into_bytes()
+}
+
+fn serve_dist_file(relative_path: &str) -> Vec<u8> {
+    let Some(path) = dist_file_path(relative_path) else {
+        return not_found_response();
+    };
+    match fs::read(&path) {
+        Ok(bytes) => {
+            let content_type = content_type_for_path(&path);
+            if content_type.starts_with("text/") || content_type == "application/javascript" {
+                return http_response(
+                    200,
+                    content_type,
+                    &String::from_utf8_lossy(&bytes),
+                );
+            }
+            binary_response(content_type, &bytes)
+        }
+        Err(_) => not_found_response(),
+    }
+}
+
+fn serve_public_file(relative_path: &str) -> Vec<u8> {
+    let clean = relative_path.trim_start_matches('/');
+    if clean.contains("..") {
+        return not_found_response();
+    }
+    let roots = public_roots();
+    let Some(path) = roots
+        .into_iter()
+        .map(|root| root.join(clean))
+        .find(|path| path.is_file())
+    else {
+        return not_found_response();
+    };
+    match fs::read(&path) {
+        Ok(bytes) => binary_response(content_type_for_path(&path), &bytes),
+        Err(_) => not_found_response(),
+    }
+}
+
+fn dist_file_path(relative_path: &str) -> Option<PathBuf> {
+    let clean = relative_path.trim_start_matches('/');
+    if clean.contains("..") {
+        return None;
+    }
+    dist_roots()
+        .into_iter()
+        .map(|root| root.join(clean))
+        .find(|path| path.is_file())
+}
+
+fn dist_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(current) = std::env::current_dir() {
+        roots.push(current.join("dist"));
+        roots.push(current.join("..").join("dist"));
+    }
+    roots.push(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..").join("dist"));
+    roots
+}
+
+fn public_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(current) = std::env::current_dir() {
+        roots.push(current.join("public"));
+        roots.push(current.join("..").join("public"));
+    }
+    roots.push(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..").join("public"));
+    roots
+}
+
+fn content_type_for_path(path: &Path) -> &'static str {
+    match path.extension().and_then(|ext| ext.to_str()).unwrap_or("") {
+        "html" => "text/html; charset=utf-8",
+        "css" => "text/css; charset=utf-8",
+        "js" => "application/javascript",
+        "json" => "application/json",
+        "png" => "image/png",
+        "svg" => "image/svg+xml",
+        "woff2" => "font/woff2",
+        "woff" => "font/woff",
+        "ttf" => "font/ttf",
+        _ => "application/octet-stream",
+    }
 }
 
 #[cfg(test)]
@@ -168,14 +788,18 @@ mod tests {
     use super::{build_pairing_info, response_for_path};
 
     #[test]
-    fn pairing_url_contains_encoded_base_and_token() {
+    fn pairing_url_opens_vite_mobile_entry() {
         let info = build_pairing_info("192.168.1.20", 3456, "abc");
 
         assert_eq!(info.http_base_url, "http://192.168.1.20:3456");
-        assert_eq!(
-            info.url,
-            "polyui://pair?base=http%3A%2F%2F192%2E168%2E1%2E20%3A3456&token=abc"
-        );
+        assert_eq!(info.url, "http://192.168.1.20:3456/mobile.html?token=abc");
+    }
+
+    #[test]
+    fn mobile_entry_rejects_wrong_token() {
+        let response = response_for_path("/mobile.html?token=nope", "abc");
+
+        assert!(response.starts_with("HTTP/1.1 401 Unauthorized"));
     }
 
     #[test]

--- a/src-tauri/src/mobile_pairing.rs
+++ b/src-tauri/src/mobile_pairing.rs
@@ -1,0 +1,195 @@
+use serde::Serialize;
+use std::net::{IpAddr, Ipv4Addr, UdpSocket};
+use std::sync::Arc;
+use tauri::State;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{oneshot, Mutex};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MobilePairingInfo {
+    pub url: String,
+    pub http_base_url: String,
+    pub host: String,
+    pub port: u16,
+    pub token: String,
+}
+
+pub struct MobilePairingState {
+    current: Mutex<Option<MobilePairingSession>>,
+}
+
+struct MobilePairingSession {
+    info: MobilePairingInfo,
+    stop: oneshot::Sender<()>,
+}
+
+impl Default for MobilePairingState {
+    fn default() -> Self {
+        Self {
+            current: Mutex::new(None),
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn mobile_pairing_start(
+    state: State<'_, MobilePairingState>,
+) -> Result<MobilePairingInfo, String> {
+    let mut current = state.current.lock().await;
+    if let Some(session) = current.as_ref() {
+        return Ok(session.info.clone());
+    }
+
+    let host = lan_ip().unwrap_or(Ipv4Addr::LOCALHOST).to_string();
+    let listener = TcpListener::bind((Ipv4Addr::UNSPECIFIED, 0))
+        .await
+        .map_err(|error| format!("Failed to start mobile pairing: {error}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|error| format!("Failed to read pairing port: {error}"))?
+        .port();
+    let token = Uuid::new_v4().to_string();
+    let info = build_pairing_info(&host, port, &token);
+    let (stop_tx, stop_rx) = oneshot::channel();
+
+    tokio::spawn(run_pairing_server(listener, token, stop_rx));
+    *current = Some(MobilePairingSession {
+        info: info.clone(),
+        stop: stop_tx,
+    });
+
+    Ok(info)
+}
+
+#[tauri::command]
+pub async fn mobile_pairing_stop(state: State<'_, MobilePairingState>) -> Result<(), String> {
+    let mut current = state.current.lock().await;
+    if let Some(session) = current.take() {
+        let _ = session.stop.send(());
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn mobile_pairing_status(
+    state: State<'_, MobilePairingState>,
+) -> Result<Option<MobilePairingInfo>, String> {
+    Ok(state.current.lock().await.as_ref().map(|session| session.info.clone()))
+}
+
+fn build_pairing_info(host: &str, port: u16, token: &str) -> MobilePairingInfo {
+    let http_base_url = format!("http://{host}:{port}");
+    let encoded_base = percent_encoding::utf8_percent_encode(
+        &http_base_url,
+        percent_encoding::NON_ALPHANUMERIC,
+    );
+    let url = format!("polyui://pair?base={encoded_base}&token={token}");
+    MobilePairingInfo {
+        url,
+        http_base_url,
+        host: host.to_string(),
+        port,
+        token: token.to_string(),
+    }
+}
+
+fn lan_ip() -> Option<Ipv4Addr> {
+    let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
+    socket.connect((Ipv4Addr::new(8, 8, 8, 8), 80)).ok()?;
+    match socket.local_addr().ok()?.ip() {
+        IpAddr::V4(ip) if !ip.is_loopback() => Some(ip),
+        _ => None,
+    }
+}
+
+async fn run_pairing_server(
+    listener: TcpListener,
+    token: String,
+    mut stop: oneshot::Receiver<()>,
+) {
+    let token = Arc::new(token);
+    loop {
+        tokio::select! {
+            _ = &mut stop => break,
+            accepted = listener.accept() => {
+                let Ok((stream, _addr)) = accepted else { continue };
+                let token = Arc::clone(&token);
+                tokio::spawn(async move {
+                    let _ = handle_connection(stream, token.as_str()).await;
+                });
+            }
+        }
+    }
+}
+
+async fn handle_connection(mut stream: TcpStream, token: &str) -> std::io::Result<()> {
+    let mut buffer = [0_u8; 2048];
+    let read = stream.read(&mut buffer).await?;
+    let request = String::from_utf8_lossy(&buffer[..read]);
+    let path = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("/");
+    let response = response_for_path(path, token);
+    stream.write_all(response.as_bytes()).await
+}
+
+fn response_for_path(path: &str, token: &str) -> String {
+    if path == "/health" {
+        return http_response(200, r#"{"ok":true,"app":"PolyUI"}"#);
+    }
+
+    let expected = format!("/pair/verify?token={token}");
+    if path == expected {
+        return http_response(200, r#"{"ok":true,"app":"PolyUI"}"#);
+    }
+
+    http_response(401, r#"{"ok":false}"#)
+}
+
+fn http_response(status: u16, body: &str) -> String {
+    let reason = match status {
+        200 => "OK",
+        401 => "Unauthorized",
+        _ => "Error",
+    };
+    format!(
+        "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_pairing_info, response_for_path};
+
+    #[test]
+    fn pairing_url_contains_encoded_base_and_token() {
+        let info = build_pairing_info("192.168.1.20", 3456, "abc");
+
+        assert_eq!(info.http_base_url, "http://192.168.1.20:3456");
+        assert_eq!(
+            info.url,
+            "polyui://pair?base=http%3A%2F%2F192%2E168%2E1%2E20%3A3456&token=abc"
+        );
+    }
+
+    #[test]
+    fn verify_accepts_matching_token() {
+        let response = response_for_path("/pair/verify?token=abc", "abc");
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains(r#""ok":true"#));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_token() {
+        let response = response_for_path("/pair/verify?token=nope", "abc");
+
+        assert!(response.starts_with("HTTP/1.1 401 Unauthorized"));
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import { GlobalConfirmDialog } from "./components/ui/GlobalConfirmDialog";
 import { useDevStore } from "@/store/devStore";
 import { getDevComponentGalleryAction } from "@/features/dev/componentGalleryAction";
 import { AgentViewportDrawer } from "@/features/agent/AgentViewportDrawer";
+import { listen } from "@tauri-apps/api/event";
 
 const AuthModalLazy = lazy(() =>
   import("@/features/auth/AuthModal").then((module) => ({
@@ -176,6 +177,24 @@ function App() {
     useFolderStore.getState().actions.setActiveFolderId(null);
     setActiveConversationId(null);
   }, [setActiveConversationId]);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    void listen<{ conversationId?: string }>("mobile-chat-updated", (event) => {
+      const changedId = event.payload.conversationId;
+      const store = useChatStore.getState();
+      void store.actions.loadConversations().then(() => {
+        if (changedId && store.activeConversationId === changedId) {
+          void store.actions.setActiveConversationId(changedId);
+        }
+      });
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, []);
 
   const handleSelectConversation = useCallback(
     (id: string) => {

--- a/src/features/chat/components/MobileChatInput.tsx
+++ b/src/features/chat/components/MobileChatInput.tsx
@@ -1,0 +1,97 @@
+import { memo, useCallback, useRef, useState } from "react";
+import { ArrowUp, Square } from "lucide-react";
+import { Box } from "@/components/ui/Box";
+import { Button } from "@/components/ui/button";
+import { InputBase } from "@/components/ui/input-base";
+import { cn } from "@/lib/utils";
+
+type MobileChatInputProps = {
+  onSubmit: (value: string) => void | Promise<void>;
+  onStop?: () => void;
+  isStreaming: boolean;
+  disabled?: boolean;
+  status?: string;
+  isTemporary?: boolean;
+};
+
+export const MobileChatInput = memo(function MobileChatInput({
+  onSubmit,
+  onStop,
+  isStreaming,
+  disabled,
+  status,
+  isTemporary,
+}: MobileChatInputProps) {
+  const [draft, setDraft] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const hasContent = draft.trim().length > 0;
+
+  const submit = useCallback(() => {
+    if (isStreaming) {
+      onStop?.();
+      return;
+    }
+    const value = draft.trim();
+    if (!value || disabled) return;
+    setDraft("");
+    void onSubmit(value);
+  }, [disabled, draft, isStreaming, onStop, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        submit();
+      }
+    },
+    [submit],
+  );
+
+  return (
+    <Box className="relative w-full">
+      <Box
+        className={cn(
+          "w-full rounded-3xl border bg-popover px-4 py-3 shadow-sm transition-colors duration-[var(--dur-fast)] ease-[var(--ease-soft)]",
+          isTemporary
+            ? "border-dashed border-border/60"
+            : "border-transparent hover:border-border/60 focus-within:border-border/60",
+        )}
+        aria-label="Chat message composer"
+      >
+        <Box className="relative flex min-h-16 flex-col">
+          <InputBase
+            multiline
+            inputRef={textareaRef}
+            minRows={1}
+            placeholder="How can I help you today?"
+            value={draft}
+            className="min-h-8 resize-none text-sm leading-6 placeholder:text-muted-foreground"
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={disabled && !isStreaming}
+          />
+
+          <Box className="mt-5 flex items-center justify-between gap-2 px-0 pb-0">
+            <Box className="min-w-0 truncate text-xs text-muted-foreground">
+              {status}
+            </Box>
+            <Button
+              type="button"
+              size="icon"
+              onClick={submit}
+              disabled={isStreaming ? false : disabled || !hasContent}
+              aria-label={isStreaming ? "Stop generation" : "Send message"}
+              className="size-9 rounded-full"
+            >
+              {isStreaming ? (
+                <Square size={14} fill="currentColor" />
+              ) : (
+                <ArrowUp size={18} strokeWidth={2.5} />
+              )}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+});

--- a/src/features/settings/SettingsModal.tsx
+++ b/src/features/settings/SettingsModal.tsx
@@ -18,6 +18,7 @@ import { ChatTab } from "./tabs/ChatTab";
 import { DataControlsTab } from "./tabs/DataControlsTab";
 import { GeneralTab } from "./tabs/GeneralTab";
 import { InterfaceTab } from "./tabs/InterfaceTab";
+import { MobileTab } from "./tabs/MobileTab";
 import { PersonalizationTab } from "./tabs/PersonalizationTab";
 import { ProvidersTab } from "./tabs/ProvidersTab";
 
@@ -36,6 +37,8 @@ function renderTab(tab: SettingsTabId) {
       return <InterfaceTab />;
     case "providers":
       return <ProvidersTab />;
+    case "mobile":
+      return <MobileTab />;
     case "chat":
       return <ChatTab />;
     case "audio":

--- a/src/features/settings/settingsRegistry.ts
+++ b/src/features/settings/settingsRegistry.ts
@@ -6,6 +6,7 @@ import {
   Info,
   MessageSquareText,
   Mic,
+  Smartphone,
   Shield,
   SlidersHorizontal,
   type LucideIcon,
@@ -17,6 +18,7 @@ export type SettingsTabId =
   | "general"
   | "interface"
   | "providers"
+  | "mobile"
   | "chat"
   | "audio"
   | "personalization"
@@ -70,6 +72,13 @@ export const SETTINGS_TABS: SettingsTabDefinition[] = [
     description: "Ollama, OpenAI-compatible providers, and web search.",
     icon: Cpu,
     keywords: ["connections", "providers", "models", "ollama", "openai", "web", "search", "api"],
+  },
+  {
+    id: "mobile",
+    label: "Mobile",
+    description: "Pair iOS and Android apps on the same Wi-Fi.",
+    icon: Smartphone,
+    keywords: ["mobile", "phone", "ios", "android", "wifi", "wi-fi", "pair", "qr"],
   },
   {
     id: "chat",

--- a/src/features/settings/tabs/MobileTab.tsx
+++ b/src/features/settings/tabs/MobileTab.tsx
@@ -2,9 +2,12 @@ import { useEffect, useState } from "react";
 import { Copy, RefreshCw, Square } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { QRCodeSVG } from "qrcode.react";
+import { useShallow } from "zustand/react/shallow";
 import { Button } from "@/components/ui/button";
 import { Stack } from "@/components/ui/Stack";
+import { Switch } from "@/components/ui/switch";
 import { Typography } from "@/components/ui/Typography";
+import { useSettingsStore } from "@/store/settingsStore";
 import { SettingRow, SettingsSection } from "../SettingsShell";
 
 type MobilePairingInfo = {
@@ -19,6 +22,14 @@ export function MobileTab() {
   const [pairing, setPairing] = useState<MobilePairingInfo | null>(null);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const { experimentalFeatures, mobileWebAccess, actions } = useSettingsStore(
+    useShallow((state) => ({
+      experimentalFeatures: state.general.experimentalFeatures,
+      mobileWebAccess: state.general.mobileWebAccess,
+      actions: state.actions,
+    })),
+  );
+  const canUseMobileWeb = experimentalFeatures && mobileWebAccess;
 
   useEffect(() => {
     let cancelled = false;
@@ -32,7 +43,18 @@ export function MobileTab() {
     };
   }, []);
 
+  useEffect(() => {
+    if (canUseMobileWeb || !pairing) return;
+    void invoke("mobile_pairing_stop")
+      .then(() => setPairing(null))
+      .catch(() => undefined);
+  }, [canUseMobileWeb, pairing]);
+
   async function startPairing() {
+    if (!canUseMobileWeb) {
+      setMessage("Enable Experimental features and Mobile web access first.");
+      return;
+    }
     setBusy(true);
     setMessage(null);
     try {
@@ -72,42 +94,62 @@ export function MobileTab() {
       title="Mobile Pairing"
       description="Connect a future PolyUI mobile app from the same Wi-Fi network."
     >
-      <SettingRow
-        title={pairing ? "Pairing is active" : "Start Wi-Fi pairing"}
-        description={
-          pairing
-            ? `Listening at ${pairing.httpBaseUrl}. Keep this window open while pairing.`
-            : "Creates a temporary QR code. No cloud server or account required."
-        }
-        action={
-          pairing ? (
-            <Button type="button" variant="outline" size="sm" disabled={busy} onClick={stopPairing} startIcon={<Square />}>
-              Stop
-            </Button>
-          ) : (
-            <Button type="button" size="sm" disabled={busy} onClick={startPairing} startIcon={<RefreshCw />}>
-              Start Pairing
-            </Button>
-          )
-        }
-      >
-        {pairing ? (
-          <Stack spacing={3}>
-            <div className="w-fit rounded-xl border border-border/60 bg-white p-3">
-              <QRCodeSVG value={pairing.url} size={184} marginSize={1} />
-            </div>
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              <code className="min-w-0 flex-1 truncate rounded-lg bg-muted px-3 py-2 text-xs text-muted-foreground">
-                {pairing.url}
-              </code>
-              <Button type="button" variant="outline" size="sm" onClick={copyUrl} startIcon={<Copy />}>
-                Copy
+      {experimentalFeatures ? (
+        <SettingRow
+          title="Mobile web access"
+          description="Allow phones on the same Wi-Fi to open the browser client."
+          action={
+            <Switch
+              checked={mobileWebAccess}
+              onCheckedChange={(checked) => actions.updateGeneral({ mobileWebAccess: checked })}
+              aria-label="Toggle mobile web access"
+            />
+          }
+        />
+      ) : (
+        <SettingRow
+          title="Experimental features required"
+          description="Turn on Experimental features in Advanced Settings to use mobile web access."
+        />
+      )}
+      {canUseMobileWeb ? (
+        <SettingRow
+          title={pairing ? "Pairing is active" : "Start Wi-Fi pairing"}
+          description={
+            pairing
+              ? `Listening at ${pairing.httpBaseUrl}. Keep this window open while pairing.`
+              : "Creates a temporary QR code. No cloud server or account required."
+          }
+          action={
+            pairing ? (
+              <Button type="button" variant="outline" size="sm" disabled={busy} onClick={stopPairing} startIcon={<Square />}>
+                Stop
               </Button>
-            </div>
-          </Stack>
-        ) : null}
-        {message ? <Typography className="text-sm text-muted-foreground">{message}</Typography> : null}
-      </SettingRow>
+            ) : (
+              <Button type="button" size="sm" disabled={busy} onClick={startPairing} startIcon={<RefreshCw />}>
+                Start Pairing
+              </Button>
+            )
+          }
+        >
+          {pairing ? (
+            <Stack spacing={3}>
+              <div className="w-fit rounded-xl border border-border/60 bg-white p-3">
+                <QRCodeSVG value={pairing.url} size={184} marginSize={1} />
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <code className="min-w-0 flex-1 truncate rounded-lg bg-muted px-3 py-2 text-xs text-muted-foreground">
+                  {pairing.url}
+                </code>
+                <Button type="button" variant="outline" size="sm" onClick={copyUrl} startIcon={<Copy />}>
+                  Copy
+                </Button>
+              </div>
+            </Stack>
+          ) : null}
+          {message ? <Typography className="text-sm text-muted-foreground">{message}</Typography> : null}
+        </SettingRow>
+      ) : null}
       <SettingRow
         title="Connection limits"
         description="Phone and computer must be on the same Wi-Fi. Firewall or VPN settings can block pairing."

--- a/src/features/settings/tabs/MobileTab.tsx
+++ b/src/features/settings/tabs/MobileTab.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { Copy, RefreshCw, Square } from "lucide-react";
+import { invoke } from "@tauri-apps/api/core";
+import { QRCodeSVG } from "qrcode.react";
+import { Button } from "@/components/ui/button";
+import { Stack } from "@/components/ui/Stack";
+import { Typography } from "@/components/ui/Typography";
+import { SettingRow, SettingsSection } from "../SettingsShell";
+
+type MobilePairingInfo = {
+  url: string;
+  httpBaseUrl: string;
+  host: string;
+  port: number;
+  token: string;
+};
+
+export function MobileTab() {
+  const [pairing, setPairing] = useState<MobilePairingInfo | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void invoke<MobilePairingInfo | null>("mobile_pairing_status")
+      .then((info) => {
+        if (!cancelled) setPairing(info);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function startPairing() {
+    setBusy(true);
+    setMessage(null);
+    try {
+      setPairing(await invoke<MobilePairingInfo>("mobile_pairing_start"));
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function stopPairing() {
+    setBusy(true);
+    setMessage(null);
+    try {
+      await invoke("mobile_pairing_stop");
+      setPairing(null);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copyUrl() {
+    if (!pairing) return;
+    try {
+      await navigator.clipboard.writeText(pairing.url);
+      setMessage("Pairing URL copied.");
+    } catch {
+      setMessage("Copy failed. Select the pairing URL and copy it manually.");
+    }
+  }
+
+  return (
+    <SettingsSection
+      title="Mobile Pairing"
+      description="Connect a future PolyUI mobile app from the same Wi-Fi network."
+    >
+      <SettingRow
+        title={pairing ? "Pairing is active" : "Start Wi-Fi pairing"}
+        description={
+          pairing
+            ? `Listening at ${pairing.httpBaseUrl}. Keep this window open while pairing.`
+            : "Creates a temporary QR code. No cloud server or account required."
+        }
+        action={
+          pairing ? (
+            <Button type="button" variant="outline" size="sm" disabled={busy} onClick={stopPairing} startIcon={<Square />}>
+              Stop
+            </Button>
+          ) : (
+            <Button type="button" size="sm" disabled={busy} onClick={startPairing} startIcon={<RefreshCw />}>
+              Start Pairing
+            </Button>
+          )
+        }
+      >
+        {pairing ? (
+          <Stack spacing={3}>
+            <div className="w-fit rounded-xl border border-border/60 bg-white p-3">
+              <QRCodeSVG value={pairing.url} size={184} marginSize={1} />
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <code className="min-w-0 flex-1 truncate rounded-lg bg-muted px-3 py-2 text-xs text-muted-foreground">
+                {pairing.url}
+              </code>
+              <Button type="button" variant="outline" size="sm" onClick={copyUrl} startIcon={<Copy />}>
+                Copy
+              </Button>
+            </div>
+          </Stack>
+        ) : null}
+        {message ? <Typography className="text-sm text-muted-foreground">{message}</Typography> : null}
+      </SettingRow>
+      <SettingRow
+        title="Connection limits"
+        description="Phone and computer must be on the same Wi-Fi. Firewall or VPN settings can block pairing."
+      />
+    </SettingsSection>
+  );
+}

--- a/src/features/settings/tabs/SpeechTab.tsx
+++ b/src/features/settings/tabs/SpeechTab.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useRef } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { Channel, invoke } from "@tauri-apps/api/core";
 import { useShallow } from "zustand/react/shallow";
 import {
   AlertCircle,
@@ -66,6 +66,8 @@ export function SpeechTab() {
   const notify = useNotify();
 
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [supertonicVoices, setSupertonicVoices] = useState<string[]>([]);
+  const [supertonicLoading, setSupertonicLoading] = useState(false);
   const [speechSupported, setSpeechSupported] = useState(true);
   const shownErrorsRef = useRef<Set<string>>(new Set());
 
@@ -89,6 +91,27 @@ export function SpeechTab() {
     };
   }, []);
 
+  const usesSupertonicControls = tts.engine === "supertonic" || (tts.engine === "auto" && !speechSupported);
+  const usesNativeControls = tts.engine === "native" || (tts.engine === "auto" && speechSupported);
+
+  useEffect(() => {
+    if (!usesSupertonicControls || supertonicVoices.length > 0 || supertonicLoading) return;
+
+    setSupertonicLoading(true);
+    void invoke("plugin:supertonic|load_model", {
+      modelId: "Supertone/supertonic-3",
+      voiceStyle: tts.supertonic.voiceName,
+      onProgress: new Channel(),
+    })
+      .then(() => invoke<string[]>("plugin:supertonic|list_voices"))
+      .then(setSupertonicVoices)
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : "Could not load Supertonic voices.";
+        notify.error("Speech error", message);
+      })
+      .finally(() => setSupertonicLoading(false));
+  }, [notify, supertonicLoading, supertonicVoices.length, tts.supertonic.voiceName, usesSupertonicControls]);
+
   useEffect(() => {
     if (ttsPlayback.error && !shownErrorsRef.current.has(ttsPlayback.error)) {
       shownErrorsRef.current.add(ttsPlayback.error);
@@ -110,7 +133,7 @@ export function SpeechTab() {
   };
 
   const isTesting = ttsPlayback.activeMessageId === "test-synthesis";
-  const isDisabled = (ttsPlayback.isGenerating && !isTesting) || !speechSupported;
+  const isDisabled = ttsPlayback.isGenerating && !isTesting;
 
   const appendTranscript = useCallback(() => {}, []);
   const {
@@ -154,20 +177,44 @@ export function SpeechTab() {
         description="Configure native system speech synthesis for reading assistant messages."
       />
 
+      <SettingCard
+        title="Speech Engine"
+        description="Choose the voice engine for reading messages."
+        action={
+          <Select
+            value={tts.engine}
+            onValueChange={(value) =>
+              actions.updateTts({ engine: value as typeof tts.engine })
+            }
+          >
+            <SelectTrigger size="sm" className={selectClassName}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="auto">Auto</SelectItem>
+                <SelectItem value="native">Native</SelectItem>
+                <SelectItem value="supertonic">Supertonic</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        }
+      />
+
       {!speechSupported ? (
         <Box
         >
           <AlertCircle size={18} />
           <Typography variant="body2">
-            Native speech synthesis is not supported or disabled on your system.
+            Native speech synthesis is unavailable. Supertonic will be used instead.
           </Typography>
         </Box>
       ) : null}
 
-      {speechSupported ? (
+      {usesNativeControls ? (
         <>
           <SettingCard
-            title="Voice"
+            title="Native Voice"
             description="Select the system voice to use for reading messages."
             action={
               <Select
@@ -239,6 +286,95 @@ export function SpeechTab() {
               >
                 {tts.browser.pitch.toFixed(1)}
               </Typography>
+            </Box>
+          </SettingCard>
+        </>
+      ) : null}
+
+      {usesSupertonicControls ? (
+        <>
+          <SettingCard
+            title="Supertonic Voice"
+            description="Select the local Supertonic voice style."
+            action={
+              <Select
+                value={tts.supertonic.voiceName}
+                disabled={supertonicLoading}
+                onValueChange={(value) =>
+                  actions.updateTts({
+                    supertonic: { ...tts.supertonic, voiceName: value },
+                  })
+                }
+              >
+                <SelectTrigger size="sm" className={selectClassName}>
+                  <SelectValue placeholder={supertonicLoading ? "Loading voices..." : "Select voice"} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {(supertonicVoices.length > 0 ? supertonicVoices : [tts.supertonic.voiceName]).map((voice) => (
+                      <SelectItem key={voice} value={voice}>
+                        {voice}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            }
+          />
+
+          <SettingCard title="Supertonic Speed" description="Adjust local voice reading speed.">
+            <Box>
+              <Slider
+                value={tts.supertonic.speed}
+                min={0.5}
+                max={2.0}
+                step={0.1}
+                valueLabelDisplay="auto"
+                valueLabelFormat={(value) => `${value.toFixed(1)}x`}
+                onChange={(_, value) =>
+                  actions.updateTts({
+                    supertonic: { ...tts.supertonic, speed: value as number },
+                  })
+                }
+              />
+              <Typography>{tts.supertonic.speed.toFixed(1)}x</Typography>
+            </Box>
+          </SettingCard>
+
+          <SettingCard title="Supertonic Steps" description="Adjust synthesis detail.">
+            <Box>
+              <Slider
+                value={tts.supertonic.totalStep}
+                min={3}
+                max={20}
+                step={1}
+                valueLabelDisplay="auto"
+                onChange={(_, value) =>
+                  actions.updateTts({
+                    supertonic: { ...tts.supertonic, totalStep: value as number },
+                  })
+                }
+              />
+              <Typography>{tts.supertonic.totalStep}</Typography>
+            </Box>
+          </SettingCard>
+
+          <SettingCard title="Supertonic Silence" description="Adjust pause between segments.">
+            <Box>
+              <Slider
+                value={tts.supertonic.silenceDuration}
+                min={0}
+                max={1}
+                step={0.05}
+                valueLabelDisplay="auto"
+                valueLabelFormat={(value) => `${value.toFixed(2)}s`}
+                onChange={(_, value) =>
+                  actions.updateTts({
+                    supertonic: { ...tts.supertonic, silenceDuration: value as number },
+                  })
+                }
+              />
+              <Typography>{tts.supertonic.silenceDuration.toFixed(2)}s</Typography>
             </Box>
           </SettingCard>
         </>

--- a/src/mobile.tsx
+++ b/src/mobile.tsx
@@ -1,0 +1,446 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import ReactDOM from "react-dom/client";
+import { Menu, Plus, Trash2, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { NotificationProvider } from "@/components/ui/Toast/NotificationProvider";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ChatArea } from "@/features/chat/components/ChatArea";
+import { MobileChatInput } from "@/features/chat/components/MobileChatInput";
+import { useChatStore } from "@/store/chatStore";
+import type { Conversation, Message } from "@/types/chat";
+import type { ModelProvider } from "@/store/modelStore";
+import "./App.css";
+
+type ModelChoice = {
+  name: string;
+  providerType: ModelProvider;
+  providerConfigId: number;
+};
+
+type RemoteChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+  attachments?: Message["attachments"];
+};
+
+type ApiResult<T> =
+  | ({ ok: true } & T)
+  | { ok: false; error?: string };
+
+function tokenFromUrl() {
+  return new URLSearchParams(window.location.search).get("token") ?? "";
+}
+
+async function api<T>(path: string, token: string, init?: RequestInit): Promise<ApiResult<T>> {
+  const separator = path.includes("?") ? "&" : "?";
+  const response = await fetch(`${path}${separator}token=${encodeURIComponent(token)}`, init);
+  return response.json() as Promise<ApiResult<T>>;
+}
+
+function newConversation(isTemporary: boolean): Conversation {
+  const now = new Date().toISOString();
+  return {
+    id: uuid(),
+    title: "New Chat",
+    createdAt: now,
+    updatedAt: now,
+    isArchived: false,
+    isTemporary,
+    titleSource: "default",
+  };
+}
+
+function MobileApp() {
+  const token = useMemo(tokenFromUrl, []);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const [models, setModels] = useState<ModelChoice[]>([]);
+  const [selectedModel, setSelectedModel] = useState("");
+  const [status, setStatus] = useState("Connecting...");
+  const [busy, setBusy] = useState(false);
+  const [temporary, setTemporary] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const conversations = useChatStore((state) => state.conversations);
+  const activeConversationId = useChatStore((state) => state.activeConversationId);
+  const messages = useChatStore((state) => state.messages);
+  const activeConversation = conversations.find((conversation) => conversation.id === activeConversationId);
+  const selectedChoice = models.find((choice) => modelKey(choice) === selectedModel) ?? models[0];
+
+  useEffect(() => {
+    if (!token) {
+      setStatus("Missing pairing token.");
+      return;
+    }
+
+    let cancelled = false;
+    async function load() {
+      const statusResult = await api<Record<string, never>>("/api/status", token);
+      if (!statusResult.ok) throw new Error(statusResult.error ?? "Pairing token rejected.");
+
+      const [modelResult, conversationResult] = await Promise.all([
+        api<{ models: ModelChoice[] }>("/api/models", token),
+        api<{ conversations: Conversation[] }>("/api/conversations", token),
+      ]);
+      if (!modelResult.ok) throw new Error(modelResult.error ?? "Could not load models.");
+      if (!conversationResult.ok) throw new Error(conversationResult.error ?? "Could not load chats.");
+      if (cancelled) return;
+
+      setModels(modelResult.models);
+      setSelectedModel(modelResult.models[0] ? modelKey(modelResult.models[0]) : "");
+      useChatStore.setState({
+        conversations: conversationResult.conversations,
+        activeConversationId: conversationResult.conversations[0]?.id ?? null,
+      });
+      if (conversationResult.conversations[0]) {
+        await loadMessages(conversationResult.conversations[0].id);
+      }
+      setStatus(modelResult.models.length ? "Connected to desktop." : "Connected. No provider models found.");
+    }
+
+    load().catch((error) => {
+      if (!cancelled) setStatus(error instanceof Error ? error.message : String(error));
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  async function loadMessages(conversationId: string) {
+    const result = await api<{ messages: Message[] }>(
+      `/api/messages?conversationId=${encodeURIComponent(conversationId)}`,
+      token,
+    );
+    if (!result.ok) throw new Error(result.error ?? "Could not load messages.");
+    useChatStore.setState({
+      activeConversationId: conversationId,
+      messages: result.messages,
+      hasMoreMessages: false,
+    });
+  }
+
+  async function createChat(nextTemporary = temporary) {
+    const conversation = newConversation(nextTemporary);
+    useChatStore.setState((state) => ({
+      conversations: [conversation, ...state.conversations],
+      activeConversationId: conversation.id,
+      messages: [],
+    }));
+    if (!nextTemporary) {
+      await api<Record<string, never>>("/api/conversations", token, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          id: conversation.id,
+          title: conversation.title,
+          isTemporary: false,
+        }),
+      });
+    }
+  }
+
+  async function submit(content: string) {
+    if (!content || !selectedChoice || busy) return;
+
+    let conversation = activeConversation;
+    if (!conversation) {
+      conversation = newConversation(temporary);
+      useChatStore.setState((state) => ({
+        conversations: [conversation!, ...state.conversations],
+        activeConversationId: conversation!.id,
+        messages: [],
+      }));
+      if (!conversation.isTemporary) {
+        await api<Record<string, never>>("/api/conversations", token, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: conversation.id, title: conversation.title }),
+        });
+      }
+    }
+
+    const userMessage: Message = {
+      id: uuid(),
+      conversationId: conversation.id,
+      role: "user",
+      content,
+      createdAt: new Date().toISOString(),
+      model: selectedChoice.name,
+      provider: selectedChoice.providerType,
+    };
+    setBusy(true);
+    setStatus("Thinking...");
+    useChatStore.setState((state) => ({
+      messages: [...state.messages, userMessage],
+      conversations: state.conversations.map((item) =>
+        item.id === conversation!.id
+          ? { ...item, title: item.title === "New Chat" ? content.slice(0, 48) : item.title, updatedAt: userMessage.createdAt }
+          : item,
+      ),
+    }));
+
+    if (!conversation.isTemporary) {
+      await api<Record<string, never>>("/api/messages", token, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          id: userMessage.id,
+          conversation_id: conversation.id,
+          role: userMessage.role,
+          content: userMessage.content,
+          model: selectedChoice.name,
+          provider: selectedChoice.providerType,
+          is_temporary: false,
+        }),
+      });
+    }
+
+    try {
+      const chatMessages: RemoteChatMessage[] = [...messages, userMessage].map((message) => ({
+        role: message.role,
+        content: message.content,
+        attachments: message.attachments,
+      }));
+      const assistant: Message = {
+        id: uuid(),
+        conversationId: conversation.id,
+        role: "assistant",
+        content: "",
+        createdAt: new Date().toISOString(),
+        model: selectedChoice.name,
+        provider: selectedChoice.providerType,
+        isStreaming: true,
+        status: "streaming",
+      };
+      useChatStore.setState((state) => ({ messages: [...state.messages, assistant] }));
+      await streamChat("/api/chat-stream", token, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: selectedChoice.name,
+          messages: chatMessages,
+          conversation_id: conversation.id,
+          is_temporary: Boolean(conversation.isTemporary),
+          provider_type: selectedChoice.providerType,
+          provider_config_id: selectedChoice.providerConfigId,
+        }),
+      }, {
+        onChunk: (chunk) => {
+          assistant.content += chunk;
+          useChatStore.setState((state) => ({
+            messages: state.messages.map((message) =>
+              message.id === assistant.id ? { ...assistant } : message,
+            ),
+          }));
+        },
+        onDone: (id) => {
+          const previousId = assistant.id;
+          assistant.id = id || assistant.id;
+          assistant.isStreaming = false;
+          assistant.status = "complete";
+          useChatStore.setState((state) => ({
+            messages: state.messages.map((message) =>
+              message.id === previousId ? { ...assistant } : message,
+            ),
+          }));
+        },
+      });
+      setStatus("Connected to desktop.");
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="flex h-dvh bg-background text-foreground">
+      <aside className="hidden w-64 shrink-0 border-r border-border/60 bg-muted/30 sm:flex sm:flex-col">
+        <ConversationSidebar
+          conversations={conversations}
+          activeConversationId={activeConversationId}
+          onNewChat={() => void createChat()}
+          onSelect={(id) => void loadMessages(id)}
+        />
+      </aside>
+
+      {sidebarOpen ? (
+        <div className="fixed inset-0 z-50 flex sm:hidden">
+          <button
+            type="button"
+            aria-label="Close chats"
+            className="absolute inset-0 bg-background/70"
+            onClick={() => setSidebarOpen(false)}
+          />
+          <aside className="relative z-10 flex h-full w-[82vw] max-w-80 flex-col border-r border-border/60 bg-card shadow-xl">
+            <div className="flex items-center justify-between border-b border-border/60 p-3">
+              <div className="text-sm font-semibold">Chats</div>
+              <Button type="button" size="icon-sm" variant="ghost" onClick={() => setSidebarOpen(false)}>
+                <X />
+              </Button>
+            </div>
+            <ConversationSidebar
+              conversations={conversations}
+              activeConversationId={activeConversationId}
+              onNewChat={() => {
+                setSidebarOpen(false);
+                void createChat();
+              }}
+              onSelect={(id) => {
+                setSidebarOpen(false);
+                void loadMessages(id);
+              }}
+            />
+          </aside>
+        </div>
+      ) : null}
+
+      <section className="flex min-w-0 flex-1 flex-col">
+        <header className="flex shrink-0 items-center gap-2 border-b border-border/60 px-3 py-2">
+          <Button type="button" size="icon-sm" variant="ghost" onClick={() => setSidebarOpen(true)} className="sm:hidden">
+            <Menu />
+          </Button>
+          <Button type="button" size="icon-sm" variant="ghost" onClick={() => void createChat()}>
+            <Plus />
+          </Button>
+          <select
+            value={selectedModel}
+            onChange={(event) => setSelectedModel(event.target.value)}
+            className="h-8 min-w-0 flex-1 rounded-xl border border-border/60 bg-background px-2 text-sm outline-none"
+          >
+            {models.map((choice) => (
+              <option key={modelKey(choice)} value={modelKey(choice)}>
+                {choice.name}
+              </option>
+            ))}
+          </select>
+          <label className="flex items-center gap-1 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={temporary}
+              onChange={(event) => setTemporary(event.target.checked)}
+            />
+            Temp
+          </label>
+          <Button type="button" size="icon-sm" variant="ghost" onClick={() => useChatStore.setState({ messages: [] })}>
+            <Trash2 />
+          </Button>
+        </header>
+        <div className="min-h-0 flex-1">
+          <ChatArea messages={messages} bottomRef={bottomRef} isTemporary={activeConversation?.isTemporary} />
+          <div ref={bottomRef} />
+        </div>
+        <div className="border-t border-border/60 bg-card p-3">
+          <MobileChatInput
+            onSubmit={submit}
+            isStreaming={busy}
+            disabled={!selectedChoice}
+            status={status}
+            isTemporary={activeConversation?.isTemporary}
+          />
+        </div>
+      </section>
+    </main>
+  );
+}
+
+async function streamChat(
+  path: string,
+  token: string,
+  init: RequestInit,
+  handlers: { onChunk: (chunk: string) => void; onDone: (id?: string) => void },
+) {
+  const response = await fetch(`${path}?token=${encodeURIComponent(token)}`, init);
+  if (!response.body) throw new Error("Streaming is not available.");
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const events = buffer.split("\n\n");
+    buffer = events.pop() ?? "";
+    for (const eventText of events) {
+      const event = parseSse(eventText);
+      if (event.event === "chunk") {
+        handlers.onChunk(String(event.data.content ?? ""));
+      } else if (event.event === "done") {
+        handlers.onDone(typeof event.data.id === "string" ? event.data.id : undefined);
+      } else if (event.event === "error") {
+        throw new Error(String(event.data.error ?? "Chat failed."));
+      }
+    }
+  }
+}
+
+function parseSse(text: string): { event: string; data: Record<string, unknown> } {
+  const event = text.match(/^event: (.+)$/m)?.[1] ?? "message";
+  const rawData = text.match(/^data: (.+)$/m)?.[1] ?? "{}";
+  return { event, data: JSON.parse(rawData) as Record<string, unknown> };
+}
+
+function modelKey(choice: ModelChoice) {
+  return `${choice.providerType}:${choice.providerConfigId}:${choice.name}`;
+}
+
+function uuid() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (char) => {
+    const value = Math.floor(Math.random() * 16);
+    const nibble = char === "x" ? value : (value & 0x3) | 0x8;
+    return nibble.toString(16);
+  });
+}
+
+function ConversationSidebar({
+  conversations,
+  activeConversationId,
+  onNewChat,
+  onSelect,
+}: {
+  conversations: Conversation[];
+  activeConversationId: string | null;
+  onNewChat: () => void;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <>
+      <div className="flex items-center justify-between border-b border-border/60 p-3">
+        <div className="text-sm font-semibold">PolyUI</div>
+        <Button type="button" size="icon-sm" variant="ghost" onClick={onNewChat} aria-label="New chat">
+          <Plus />
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {conversations.length ? (
+          conversations.map((conversation) => (
+            <button
+              key={conversation.id}
+              type="button"
+              onClick={() => onSelect(conversation.id)}
+              className={`mb-1 w-full truncate rounded-xl px-3 py-2 text-left text-sm ${
+                conversation.id === activeConversationId ? "bg-accent text-accent-foreground" : "text-muted-foreground"
+              }`}
+            >
+              {conversation.title || "New Chat"}
+            </button>
+          ))
+        ) : (
+          <div className="px-3 py-4 text-sm text-muted-foreground">No chats yet.</div>
+        )}
+      </div>
+    </>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <TooltipProvider>
+      <NotificationProvider>
+        <MobileApp />
+      </NotificationProvider>
+    </TooltipProvider>
+  </React.StrictMode>,
+);

--- a/src/store/coordinator.ts
+++ b/src/store/coordinator.ts
@@ -3,7 +3,7 @@ import { useChatStore } from "./chatStore";
 import { useFolderStore } from "./folderStore";
 import { useDevStore } from "./devStore";
 import { useSettingsStore } from "./settingsStore";
-import { setTtsBrowserSettings, useTtsStore } from "./ttsStore";
+import { setTtsSettings, useTtsStore } from "./ttsStore";
 import { setUpdateInstallSimulation } from "./updateStore";
 import { getRepository } from "@/lib/repositories";
 import { deleteAgentChatSandbox } from "@/features/agent/agentClient";
@@ -50,7 +50,7 @@ export function initStoreCoordinator() {
   const initialAccountId = accountIdFromAuth(initialAuth);
   useChatStore.getState().actions.setAccountId(initialAccountId);
   useFolderStore.getState().actions.setAccountId(initialAccountId);
-  setTtsBrowserSettings(useSettingsStore.getState().tts.browser);
+  setTtsSettings(useSettingsStore.getState().tts);
   setUpdateInstallSimulation(useDevStore.getState().devMode);
 
   unsubscribeFns.push(useAuthStore.subscribe((state, prev) => {
@@ -115,8 +115,8 @@ export function initStoreCoordinator() {
   }));
 
   unsubscribeFns.push(useSettingsStore.subscribe((state, prev) => {
-    if (state.tts.browser !== prev.tts.browser) {
-      setTtsBrowserSettings(state.tts.browser);
+    if (state.tts !== prev.tts) {
+      setTtsSettings(state.tts);
     }
   }));
 

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -12,6 +12,7 @@ export type GeneralSettings = {
   webSearch: WebSearchSettings;
   webSearchEnabled: boolean;
   experimentalFeatures: boolean;
+  mobileWebAccess: boolean;
   showModelInEmptyState: boolean;
 };
 
@@ -21,8 +22,19 @@ export type BrowserTtsSettings = {
   pitch: number;
 };
 
+export type TtsEngine = "auto" | "native" | "supertonic";
+
+export type SupertonicTtsSettings = {
+  voiceName: string;
+  speed: number;
+  totalStep: number;
+  silenceDuration: number;
+};
+
 export type TtsSettings = {
+  engine: TtsEngine;
   browser: BrowserTtsSettings;
+  supertonic: SupertonicTtsSettings;
 };
 
 export type DictationSettings = {
@@ -54,14 +66,21 @@ type SettingsState = {
 };
 
 const defaultTts: TtsSettings = {
+  engine: "auto",
   browser: {
     voiceURI: "",
     speed: 1.0,
     pitch: 1.0,
   },
+  supertonic: {
+    voiceName: "M1",
+    speed: 1.0,
+    totalStep: 10,
+    silenceDuration: 0.3,
+  },
 };
 
-const SETTINGS_VERSION = 16;
+const SETTINGS_VERSION = 18;
 
 export const defaultDictation: DictationSettings = {
   enabled: true,
@@ -92,6 +111,7 @@ function defaultSettingsState(): Omit<SettingsState, "actions"> {
       webSearch: createDefaultWebSearchSettings(),
       webSearchEnabled: false,
       experimentalFeatures: false,
+      mobileWebAccess: false,
       showModelInEmptyState: false,
     },
     tts: { ...defaultTts },
@@ -116,6 +136,7 @@ export const useSettingsStore = create<SettingsState>()(
               ...s.tts,
               ...update,
               browser: { ...defaultTts.browser, ...s.tts.browser, ...(update.browser ?? {}) },
+              supertonic: { ...defaultTts.supertonic, ...s.tts.supertonic, ...(update.supertonic ?? {}) },
             },
           })),
 
@@ -141,7 +162,10 @@ export const useSettingsStore = create<SettingsState>()(
         const state = persisted as any;
         if (state?.tts) {
           state.tts = {
+            ...defaultTts,
+            ...state.tts,
             browser: { ...defaultTts.browser, ...state.tts.browser },
+            supertonic: { ...defaultTts.supertonic, ...state.tts.supertonic },
           };
         }
         if (version < 5) {
@@ -193,6 +217,9 @@ export const useSettingsStore = create<SettingsState>()(
         }
         if (version < 16) {
           state.performance = { ...defaultPerformance, ...state.performance, keepViewportActive: false };
+        }
+        if (version < 17 && state?.general) {
+          state.general.mobileWebAccess = false;
         }
         startupPhase("settings migration complete");
         return state as SettingsState;

--- a/src/store/ttsStore.ts
+++ b/src/store/ttsStore.ts
@@ -1,3 +1,4 @@
+import { Channel, invoke } from "@tauri-apps/api/core";
 import { create } from "zustand";
 
 interface TtsState {
@@ -13,14 +14,29 @@ interface TtsState {
 
 let browserSentenceQueue: string[] = [];
 let browserSentenceIndex = 0;
-let browserSettings = {
-  voiceURI: "",
-  speed: 1,
-  pitch: 1,
+let supertonicAudio: HTMLAudioElement | null = null;
+let supertonicLoadPromise: Promise<void> | null = null;
+let ttsSettings = {
+  engine: "auto" as "auto" | "native" | "supertonic",
+  browser: {
+    voiceURI: "",
+    speed: 1,
+    pitch: 1,
+  },
+  supertonic: {
+    voiceName: "M1",
+    speed: 1,
+    totalStep: 10,
+    silenceDuration: 0.3,
+  },
 };
 
-export function setTtsBrowserSettings(settings: typeof browserSettings) {
-  browserSettings = settings;
+export function setTtsBrowserSettings(settings: typeof ttsSettings.browser) {
+  ttsSettings.browser = settings;
+}
+
+export function setTtsSettings(settings: typeof ttsSettings) {
+  ttsSettings = settings;
 }
 
 export function cleanTextForSpeech(text: string): string {
@@ -55,6 +71,53 @@ const getVoice = (voiceURI: string): SpeechSynthesisVoice | undefined => {
   return window.speechSynthesis.getVoices().find((voice) => voice.voiceURI === voiceURI);
 };
 
+const base64ToBlob = (base64: string): Blob => {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return new Blob([bytes], { type: "audio/wav" });
+};
+
+const ensureSupertonicLoaded = async () => {
+  const status = await invoke<{ engineLoaded: boolean; currentVoice: string }>("plugin:supertonic|get_status");
+  if (status.engineLoaded && status.currentVoice === ttsSettings.supertonic.voiceName) return;
+
+  supertonicLoadPromise ??= invoke("plugin:supertonic|load_model", {
+    modelId: "Supertone/supertonic-3",
+    voiceStyle: ttsSettings.supertonic.voiceName,
+    onProgress: new Channel(),
+  }).finally(() => {
+    supertonicLoadPromise = null;
+  }) as Promise<void>;
+  await supertonicLoadPromise;
+};
+
+const playSupertonic = async (text: string, set: (state: Partial<TtsState>) => void) => {
+  await ensureSupertonicLoaded();
+  const result = await invoke<{ wavBase64: string }>("plugin:supertonic|synthesize", {
+    text,
+    lang: "en",
+    speed: ttsSettings.supertonic.speed,
+    totalStep: ttsSettings.supertonic.totalStep,
+    silenceDuration: ttsSettings.supertonic.silenceDuration,
+  });
+
+  const url = URL.createObjectURL(base64ToBlob(result.wavBase64));
+  supertonicAudio = new Audio(url);
+  supertonicAudio.onended = () => {
+    URL.revokeObjectURL(url);
+    supertonicAudio = null;
+    set({ isPlaying: false, activeMessageId: null });
+  };
+  supertonicAudio.onerror = () => {
+    URL.revokeObjectURL(url);
+    supertonicAudio = null;
+    set({ error: "Supertonic speech synthesis failed.", isPlaying: false, activeMessageId: null });
+  };
+  set({ isGenerating: false, isPlaying: true });
+  await supertonicAudio.play();
+};
+
 export const useTtsStore = create<TtsState>((set, get) => ({
   activeMessageId: null,
   isPlaying: false,
@@ -66,7 +129,17 @@ export const useTtsStore = create<TtsState>((set, get) => ({
       set({ activeMessageId: messageId, isPlaying: false, isGenerating: true, error: null });
 
       try {
-        if (typeof window === "undefined" || !window.speechSynthesis) {
+        const nativeAvailable = typeof window !== "undefined" && Boolean(window.speechSynthesis);
+        if (ttsSettings.engine === "supertonic" || (!nativeAvailable && ttsSettings.engine !== "native")) {
+          const cleanedText = await cleanTextAsync(rawText);
+          if (!cleanedText || !get().isGenerating) {
+            set({ isGenerating: false, activeMessageId: null });
+            return;
+          }
+          await playSupertonic(cleanedText, set);
+          return;
+        }
+        if (!nativeAvailable) {
           throw new Error("Speech synthesis is not supported in this environment.");
         }
 
@@ -100,10 +173,10 @@ export const useTtsStore = create<TtsState>((set, get) => ({
           }
 
           const utterance = new SpeechSynthesisUtterance(browserSentenceQueue[browserSentenceIndex]);
-          const voice = getVoice(browserSettings.voiceURI);
+          const voice = getVoice(ttsSettings.browser.voiceURI);
           if (voice) utterance.voice = voice;
-          utterance.rate = browserSettings.speed;
-          utterance.pitch = browserSettings.pitch;
+          utterance.rate = ttsSettings.browser.speed;
+          utterance.pitch = ttsSettings.browser.pitch;
 
           utterance.onend = () => {
             browserSentenceIndex += 1;
@@ -112,10 +185,15 @@ export const useTtsStore = create<TtsState>((set, get) => ({
 
           utterance.onerror = (event) => {
             if (event.error !== "interrupted") {
-              set({
-                error: `Speech synthesis error: ${event.error}`,
-                isPlaying: false,
-                activeMessageId: null,
+              const fallback = ttsSettings.engine === "auto"
+                ? playSupertonic(cleanedText, set)
+                : Promise.reject();
+              void fallback.catch(() => {
+                set({
+                  error: `Speech synthesis error: ${event.error}`,
+                  isPlaying: false,
+                  activeMessageId: null,
+                });
               });
             }
           };
@@ -141,6 +219,10 @@ export const useTtsStore = create<TtsState>((set, get) => ({
 
       browserSentenceQueue = [];
       browserSentenceIndex = 0;
+      if (supertonicAudio) {
+        supertonicAudio.pause();
+        supertonicAudio = null;
+      }
       set({ activeMessageId: null, isPlaying: false, isGenerating: false });
     },
   },

--- a/tests/settingsRegistry.test.ts
+++ b/tests/settingsRegistry.test.ts
@@ -88,4 +88,13 @@ describe("settings registry", () => {
     expect(commands).toContain("settings-advanced");
     expect(commands).not.toContain('tab: "advanced"');
   });
+
+  it("mobile pairing stays behind experimental features and its own toggle", () => {
+    const store = readFileSync("src/store/settingsStore.ts", "utf8");
+    const mobileTab = readFileSync("src/features/settings/tabs/MobileTab.tsx", "utf8");
+    expect(store).toContain("mobileWebAccess: false");
+    expect(mobileTab).toContain("experimentalFeatures");
+    expect(mobileTab).toContain("mobileWebAccess");
+    expect(mobileTab).toContain("mobile_pairing_stop");
+  });
 });

--- a/tests/settingsRegistry.test.ts
+++ b/tests/settingsRegistry.test.ts
@@ -20,6 +20,7 @@ describe("settings registry", () => {
       "general",
       "interface",
       "providers",
+      "mobile",
       "chat",
       "audio",
       "personalization",
@@ -39,6 +40,8 @@ describe("settings registry", () => {
 
   it("filters tabs by labels descriptions and keywords", () => {
     expect(filterSettingsTabs("ollama").map((tab) => tab.id)).toEqual(["providers"]);
+    expect(filterSettingsTabs("ios").map((tab) => tab.id)).toEqual(["mobile"]);
+    expect(filterSettingsTabs("wifi").map((tab) => tab.id)).toEqual(["mobile"]);
     expect(filterSettingsTabs("whisper").map((tab) => tab.id)).toEqual(["audio"]);
     expect(filterSettingsTabs("prompt").map((tab) => tab.id)).toEqual(["chat"]);
     expect(filterSettingsTabs("")).toHaveLength(SETTINGS_TABS.length);

--- a/tests/ttsStore.test.ts
+++ b/tests/ttsStore.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: class {},
+  invoke,
+}));
+
+import { setTtsSettings, useTtsStore } from "../src/store/ttsStore";
+
+const play = vi.fn(() => Promise.resolve());
+
+class TestAudio {
+  onended: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  src: string;
+
+  constructor(src: string) {
+    this.src = src;
+  }
+
+  play = play;
+  pause = vi.fn();
+}
+
+describe("tts store", () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    play.mockClear();
+    setTtsSettings({
+      engine: "auto",
+      browser: { voiceURI: "", speed: 1, pitch: 1 },
+      supertonic: { voiceName: "M1", speed: 1, totalStep: 10, silenceDuration: 0.3 },
+    });
+    useTtsStore.getState().actions.stop();
+    Object.defineProperty(globalThis, "window", {
+      value: {},
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "Audio", {
+      value: TestAudio,
+      configurable: true,
+    });
+    Object.defineProperty(URL, "createObjectURL", {
+      value: vi.fn(() => "blob:supertonic"),
+      configurable: true,
+    });
+  });
+
+  it("falls back to Supertonic when native speech synthesis is unavailable", async () => {
+    invoke
+      .mockResolvedValueOnce({ engineLoaded: false, currentVoice: "", sampleRate: 44100 })
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ wavBase64: "UklGRg==", durationSecs: 1, sampleRate: 44100 });
+
+    await useTtsStore.getState().actions.play("m1", "hello");
+
+    expect(invoke).toHaveBeenCalledWith("plugin:supertonic|get_status");
+    expect(invoke).toHaveBeenCalledWith("plugin:supertonic|load_model", expect.any(Object));
+    expect(invoke).toHaveBeenCalledWith("plugin:supertonic|synthesize", expect.objectContaining({ text: "hello" }));
+    expect(play).toHaveBeenCalledTimes(1);
+    expect(useTtsStore.getState().isPlaying).toBe(true);
+  });
+
+  it("passes selected Supertonic voice and synthesis settings to the plugin", async () => {
+    setTtsSettings({
+      engine: "supertonic",
+      browser: { voiceURI: "", speed: 1, pitch: 1 },
+      supertonic: { voiceName: "F2", speed: 1.4, totalStep: 12, silenceDuration: 0.15 },
+    });
+    invoke
+      .mockResolvedValueOnce({ engineLoaded: false, currentVoice: "", sampleRate: 44100 })
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ wavBase64: "UklGRg==", durationSecs: 1, sampleRate: 44100 });
+
+    await useTtsStore.getState().actions.play("m1", "hello");
+
+    expect(invoke).toHaveBeenCalledWith("plugin:supertonic|load_model", expect.objectContaining({ voiceStyle: "F2" }));
+    expect(invoke).toHaveBeenCalledWith("plugin:supertonic|synthesize", expect.objectContaining({
+      speed: 1.4,
+      totalStep: 12,
+      silenceDuration: 0.15,
+    }));
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,10 @@ export default defineConfig(async () => ({
   },
   build: {
     rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, "index.html"),
+        mobile: path.resolve(__dirname, "mobile.html"),
+      },
       output: {
         manualChunks: {
           "vendor-markdown": ["react-markdown", "remark-gfm", "remark-math", "rehype-katex", "katex"],


### PR DESCRIPTION
### Changes

- **Supertonic TTS plugin** — add `tauri-plugin-supertonic` for local neural TTS (Rust backend + frontend bindings)
- **Engine selector** — choose between Auto, Native, and Supertonic in speech settings
- **Supertonic controls** — voice, speed, steps, silence sliders in SpeechTab
- **Mobile pairing guards** — pairing only available when Experimental Features + Mobile Web Access are both enabled; automatically stops pairing when toggled off
- **Settings migrations** — added `mobileWebAccess` and `supertonic` fields with version bumps
- **Coordinator wiring** — TTS engine/settings now flow through coordinator to ttsStore
- **Native fallback** — when native speechSynthesis fails in auto mode, falls back to Supertonic
- **Tests** — `ttsStore.test.ts` covers Supertonic fallback, settings passthrough; mobile pairing guard conditions in `settingsRegistry.test.ts`